### PR TITLE
Adding support for configurable ON/OFF states

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalBase.java
@@ -130,7 +130,15 @@ public abstract class DigitalBase<DIGITAL_TYPE extends Digital<DIGITAL_TYPE, CON
     /** {@inheritDoc} */
     @Override
     public boolean isOn() {
-        // TODO :: REVISIT STATE VS ON/OFF
-        return state().isHigh();
+        // the default ON state is HIGH
+        DigitalState onState = DigitalState.HIGH;
+
+        // get configured ON state
+        if(config().onState() != null){
+            onState = config().onState();
+        }
+
+        // return TRUE if the current state matches the configured ON state
+        return state().equals(onState);
     }
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfig.java
@@ -35,5 +35,22 @@ import com.pi4j.io.gpio.GpioConfig;
  * @version $Id: $Id
  */
 public interface DigitalConfig<CONFIG_TYPE extends Config> extends GpioConfig<CONFIG_TYPE> {
-    // MARKER INTERFACE
+
+    /** Constant <code>ON_STATE_KEY="onstate"</code> */
+    String ON_STATE_KEY = "onstate";
+    /**
+     * <p>onState.</p>
+     *
+     * @return a {@link com.pi4j.io.gpio.digital.DigitalState} object.
+     */
+    DigitalState onState();
+
+    /**
+     * <p>getOnState.</p>
+     *
+     * @return a {@link com.pi4j.io.gpio.digital.DigitalState} object.
+     */
+    default DigitalState getOnState(){
+        return this.onState();
+    }
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalConfigBuilder.java
@@ -35,5 +35,11 @@ import com.pi4j.io.gpio.GpioConfigBuilder;
  */
 public interface DigitalConfigBuilder<BUILDER_TYPE extends DigitalConfigBuilder, CONFIG_TYPE extends DigitalConfig>
         extends GpioConfigBuilder<BUILDER_TYPE, CONFIG_TYPE> {
-    // MARKER INTERFACE
+    /**
+     * <p>pull.</p>
+     *
+     * @param state a {@link com.pi4j.io.gpio.digital.DigitalState} object.
+     * @return a {@link BUILDER_TYPE} object.
+     */
+    BUILDER_TYPE onState(DigitalState state);
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutputBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutputBase.java
@@ -164,14 +164,31 @@ public abstract class DigitalOutputBase extends DigitalBase<DigitalOutput, Digit
     /** {@inheritDoc} */
     @Override
     public DigitalOutput on() throws IOException {
-        // TODO :: REVISIT STATE VS ON/OFF
-        return high();
+
+        // the default ON state is HIGH
+        DigitalState onState = DigitalState.HIGH;
+
+        // get configured ON state
+        if(config().onState() != null){
+            onState = config().onState();
+        }
+
+        // set the current state to the configured ON state
+        return state(onState);
     }
 
     /** {@inheritDoc} */
     @Override
     public DigitalOutput off() throws IOException {
-        // TODO :: REVISIT STATE VS ON/OFF
-        return low();
+        // the default OFF state is LOW
+        DigitalState offState = DigitalState.LOW;
+
+        // get configured ON state; then set OFF state to inverse of ON state
+        if(config().onState() != null){
+            offState = DigitalState.getInverseState(config().onState());
+        }
+
+        // set the current state to the configured OFF state
+        return state(offState);
     }
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalInputConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalInputConfig.java
@@ -27,6 +27,7 @@ package com.pi4j.io.gpio.digital.impl;
 
 import com.pi4j.io.gpio.digital.DigitalInput;
 import com.pi4j.io.gpio.digital.DigitalInputConfig;
+import com.pi4j.io.gpio.digital.DigitalState;
 import com.pi4j.io.gpio.digital.PullResistance;
 import com.pi4j.io.impl.IOAddressConfigBase;
 import com.pi4j.util.StringUtil;
@@ -53,6 +54,7 @@ public class DefaultDigitalInputConfig
     // private configuration properties
     protected PullResistance pullResistance = PullResistance.OFF;
     protected Long debounce = DigitalInput.DEFAULT_DEBOUNCE;
+    protected DigitalState onState = DigitalState.HIGH;
 
     /**
      * PRIVATE CONSTRUCTOR
@@ -76,6 +78,11 @@ public class DefaultDigitalInputConfig
         if(properties.containsKey(DEBOUNCE_RESISTANCE_KEY)){
             this.debounce = Long.parseLong(properties.get(DEBOUNCE_RESISTANCE_KEY));
         }
+
+        // load on-state value property
+        if(properties.containsKey(ON_STATE_KEY)){
+            this.onState = DigitalState.parse(properties.get(ON_STATE_KEY));
+        }
     }
 
     /** {@inheritDoc} */
@@ -87,4 +94,9 @@ public class DefaultDigitalInputConfig
     /** {@inheritDoc} */
     @Override
     public Long debounce() { return this.debounce; }
+
+    @Override
+    public DigitalState onState() {
+        return this.onState;
+    }
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalOutputConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalOutputConfig.java
@@ -25,8 +25,7 @@ package com.pi4j.io.gpio.digital.impl;
  * #L%
  */
 
-import com.pi4j.io.gpio.digital.DigitalOutputConfig;
-import com.pi4j.io.gpio.digital.DigitalState;
+import com.pi4j.io.gpio.digital.*;
 import com.pi4j.io.impl.IOAddressConfigBase;
 import com.pi4j.util.StringUtil;
 
@@ -45,6 +44,7 @@ public class DefaultDigitalOutputConfig
     // private configuration properties
     protected DigitalState shutdownState = null;
     protected DigitalState initialState = null;
+    protected DigitalState onState = DigitalState.HIGH;
 
     /**
      * PRIVATE CONSTRUCTOR
@@ -75,6 +75,11 @@ public class DefaultDigitalOutputConfig
         if(properties.containsKey(SHUTDOWN_STATE_KEY)){
             this.shutdownState = DigitalState.parse(properties.get(SHUTDOWN_STATE_KEY));
         }
+
+        // load on-state value property
+        if(properties.containsKey(ON_STATE_KEY)){
+            this.onState = DigitalState.parse(properties.get(ON_STATE_KEY));
+        }
     }
 
     /** {@inheritDoc} */
@@ -94,5 +99,10 @@ public class DefaultDigitalOutputConfig
     @Override
     public DigitalState initialState() {
         return this.initialState;
+    }
+
+    @Override
+    public DigitalState onState() {
+        return this.onState;
     }
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DigitalConfigBuilderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DigitalConfigBuilderBase.java
@@ -28,6 +28,8 @@ package com.pi4j.io.gpio.digital.impl;
 import com.pi4j.context.Context;
 import com.pi4j.io.gpio.digital.DigitalConfig;
 import com.pi4j.io.gpio.digital.DigitalConfigBuilder;
+import com.pi4j.io.gpio.digital.DigitalOutputConfigBuilder;
+import com.pi4j.io.gpio.digital.DigitalState;
 import com.pi4j.io.impl.IOAddressConfigBuilderBase;
 
 /**
@@ -45,5 +47,12 @@ public abstract class DigitalConfigBuilderBase<BUILDER_TYPE extends DigitalConfi
      */
     protected DigitalConfigBuilderBase(Context context){
         super(context);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public BUILDER_TYPE onState(DigitalState state) {
+        this.properties.put(DigitalConfig.ON_STATE_KEY, state.toString());
+        return (BUILDER_TYPE)this;
     }
 }

--- a/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalInputOffTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalInputOffTest.java
@@ -1,0 +1,134 @@
+package com.pi4j.test.io.gpio.digital;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: TESTING  :: Unit/Integration Tests
+ * FILENAME      :  DigitalInputOffTest.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.pi4j.Pi4J;
+import com.pi4j.context.Context;
+import com.pi4j.exception.Pi4JException;
+import com.pi4j.io.gpio.digital.DigitalInput;
+import com.pi4j.io.gpio.digital.DigitalState;
+import com.pi4j.plugin.mock.provider.gpio.digital.MockDigitalInput;
+import com.pi4j.plugin.mock.provider.gpio.digital.MockDigitalInputProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class DigitalInputOffTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(DigitalInputOffTest.class);
+
+    private Context pi4j;
+
+    @BeforeEach
+    public void beforeTest() throws Pi4JException {
+        // Initialize Pi4J with MOCK digital iput provider
+        pi4j = Pi4J.newContextBuilder().add(MockDigitalInputProvider.newInstance()).build();
+    }
+
+    @AfterEach
+    public void afterTest() {
+        try {
+            pi4j.shutdown();
+        } catch (Pi4JException e) { /* do nothing */ }
+    }
+
+    @Test
+    public void testIsOffDefault() {
+
+        // create GPIO digital input config
+        var config  = DigitalInput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Input")
+            .address(1)
+            .build();
+
+        // create GPIO digital input instance
+        var input = pi4j.din().create(config);
+
+        // set MOCK state to LOW
+        MockDigitalInput mockInput = (MockDigitalInput)input;
+        mockInput.mockState(DigitalState.LOW);
+
+        // ensure output is OFF and not ON
+        assertTrue(input.isOff());
+        assertFalse(input.isOn());
+    }
+
+    @Test
+    public void testIsOffHigh() {
+
+        // create GPIO digital input config
+        var config  = DigitalInput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Input")
+            .onState(DigitalState.HIGH)
+            .address(1)
+            .build();
+
+        // create GPIO digital input instance
+        var input = pi4j.din().create(config);
+
+        // set MOCK state to LOW
+        MockDigitalInput mockInput = (MockDigitalInput)input;
+        mockInput.mockState(DigitalState.LOW);
+
+        // ensure output is OFF and not ON
+        assertTrue(input.isOff());
+        assertFalse(input.isOn());
+    }
+
+    @Test
+    public void testIsOffLow() {
+
+        // create GPIO digital input config
+        var config  = DigitalInput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Input")
+            .onState(DigitalState.LOW)
+            .address(1)
+            .build();
+
+        // create GPIO digital input instance
+        var input = pi4j.din().create(config);
+
+        // set MOCK state to HIGH
+        MockDigitalInput mockInput = (MockDigitalInput)input;
+        mockInput.mockState(DigitalState.HIGH);
+
+        // ensure output is OFF and not ON
+        assertTrue(input.isOff());
+        assertFalse(input.isOn());
+    }
+
+}

--- a/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalInputOffTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalInputOffTest.java
@@ -68,7 +68,7 @@ public class DigitalInputOffTest {
 
         // create GPIO digital input config
         var config  = DigitalInput.newConfigBuilder(pi4j)
-            .id("test-output")
+            .id("test-input")
             .name("Test Digital Input")
             .address(1)
             .build();
@@ -80,7 +80,7 @@ public class DigitalInputOffTest {
         MockDigitalInput mockInput = (MockDigitalInput)input;
         mockInput.mockState(DigitalState.LOW);
 
-        // ensure output is OFF and not ON
+        // ensure input is OFF and not ON
         assertTrue(input.isOff());
         assertFalse(input.isOn());
     }
@@ -90,7 +90,7 @@ public class DigitalInputOffTest {
 
         // create GPIO digital input config
         var config  = DigitalInput.newConfigBuilder(pi4j)
-            .id("test-output")
+            .id("test-input")
             .name("Test Digital Input")
             .onState(DigitalState.HIGH)
             .address(1)
@@ -103,7 +103,7 @@ public class DigitalInputOffTest {
         MockDigitalInput mockInput = (MockDigitalInput)input;
         mockInput.mockState(DigitalState.LOW);
 
-        // ensure output is OFF and not ON
+        // ensure input is OFF and not ON
         assertTrue(input.isOff());
         assertFalse(input.isOn());
     }
@@ -113,7 +113,7 @@ public class DigitalInputOffTest {
 
         // create GPIO digital input config
         var config  = DigitalInput.newConfigBuilder(pi4j)
-            .id("test-output")
+            .id("test-input")
             .name("Test Digital Input")
             .onState(DigitalState.LOW)
             .address(1)
@@ -126,7 +126,7 @@ public class DigitalInputOffTest {
         MockDigitalInput mockInput = (MockDigitalInput)input;
         mockInput.mockState(DigitalState.HIGH);
 
-        // ensure output is OFF and not ON
+        // ensure input is OFF and not ON
         assertTrue(input.isOff());
         assertFalse(input.isOn());
     }

--- a/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalInputOnTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalInputOnTest.java
@@ -1,0 +1,132 @@
+package com.pi4j.test.io.gpio.digital;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: TESTING  :: Unit/Integration Tests
+ * FILENAME      :  DigitalInputOnTest.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.pi4j.Pi4J;
+import com.pi4j.context.Context;
+import com.pi4j.exception.Pi4JException;
+import com.pi4j.io.gpio.digital.DigitalInput;
+import com.pi4j.io.gpio.digital.DigitalState;
+import com.pi4j.plugin.mock.provider.gpio.digital.MockDigitalInput;
+import com.pi4j.plugin.mock.provider.gpio.digital.MockDigitalInputProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class DigitalInputOnTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(DigitalInputOnTest.class);
+
+    private Context pi4j;
+
+    @BeforeEach
+    public void beforeTest() throws Pi4JException {
+        // Initialize Pi4J with MOCK digital iput provider
+        pi4j = Pi4J.newContextBuilder().add(MockDigitalInputProvider.newInstance()).build();
+    }
+
+    @AfterEach
+    public void afterTest() {
+        try {
+            pi4j.shutdown();
+        } catch (Pi4JException e) { /* do nothing */ }
+    }
+
+    @Test
+    public void testIsOnDefault() {
+
+        // create GPIO digital input config
+        var config  = DigitalInput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Input")
+            .address(1)
+            .build();
+
+        // create GPIO digital input instance
+        var input = pi4j.din().create(config);
+
+        // set MOCK state to HIGH
+        MockDigitalInput mockInput = (MockDigitalInput)input;
+        mockInput.mockState(DigitalState.HIGH);
+
+        // ensure output is ON and not OFF
+        assertTrue(input.isOn());
+        assertFalse(input.isOff());
+    }
+
+    @Test
+    public void testIsOnHigh() {
+
+        // create GPIO digital input config
+        var config  = DigitalInput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Input")
+            .onState(DigitalState.HIGH)
+            .address(1)
+            .build();
+
+        // create GPIO digital input instance
+        var input = pi4j.din().create(config);
+
+        // set MOCK state to HIGH
+        MockDigitalInput mockInput = (MockDigitalInput)input;
+        mockInput.mockState(DigitalState.HIGH);
+
+        // ensure output is ON and not OFF
+        assertTrue(input.isOn());
+        assertFalse(input.isOff());
+    }
+
+    @Test
+    public void testIsOnLow() {
+
+        // create GPIO digital input config
+        var config  = DigitalInput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Input")
+            .onState(DigitalState.LOW)
+            .address(1)
+            .build();
+
+        // create GPIO digital input instance
+        var input = pi4j.din().create(config);
+
+        // set MOCK state to LOW
+        MockDigitalInput mockInput = (MockDigitalInput)input;
+        mockInput.mockState(DigitalState.LOW);
+
+        // ensure output is ON and not OFF
+        assertTrue(input.isOn());
+        assertFalse(input.isOff());
+    }
+}

--- a/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalInputOnTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalInputOnTest.java
@@ -67,7 +67,7 @@ public class DigitalInputOnTest {
 
         // create GPIO digital input config
         var config  = DigitalInput.newConfigBuilder(pi4j)
-            .id("test-output")
+            .id("test-input")
             .name("Test Digital Input")
             .address(1)
             .build();
@@ -79,7 +79,7 @@ public class DigitalInputOnTest {
         MockDigitalInput mockInput = (MockDigitalInput)input;
         mockInput.mockState(DigitalState.HIGH);
 
-        // ensure output is ON and not OFF
+        // ensure input is ON and not OFF
         assertTrue(input.isOn());
         assertFalse(input.isOff());
     }
@@ -89,7 +89,7 @@ public class DigitalInputOnTest {
 
         // create GPIO digital input config
         var config  = DigitalInput.newConfigBuilder(pi4j)
-            .id("test-output")
+            .id("test-input")
             .name("Test Digital Input")
             .onState(DigitalState.HIGH)
             .address(1)
@@ -102,7 +102,7 @@ public class DigitalInputOnTest {
         MockDigitalInput mockInput = (MockDigitalInput)input;
         mockInput.mockState(DigitalState.HIGH);
 
-        // ensure output is ON and not OFF
+        // ensure input is ON and not OFF
         assertTrue(input.isOn());
         assertFalse(input.isOff());
     }
@@ -112,7 +112,7 @@ public class DigitalInputOnTest {
 
         // create GPIO digital input config
         var config  = DigitalInput.newConfigBuilder(pi4j)
-            .id("test-output")
+            .id("test-input")
             .name("Test Digital Input")
             .onState(DigitalState.LOW)
             .address(1)
@@ -125,7 +125,7 @@ public class DigitalInputOnTest {
         MockDigitalInput mockInput = (MockDigitalInput)input;
         mockInput.mockState(DigitalState.LOW);
 
-        // ensure output is ON and not OFF
+        // ensure input is ON and not OFF
         assertTrue(input.isOn());
         assertFalse(input.isOff());
     }

--- a/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalOutputOffTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalOutputOffTest.java
@@ -1,0 +1,211 @@
+package com.pi4j.test.io.gpio.digital;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: TESTING  :: Unit/Integration Tests
+ * FILENAME      :  DigitalOutputOffTest.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.pi4j.Pi4J;
+import com.pi4j.context.Context;
+import com.pi4j.exception.Pi4JException;
+import com.pi4j.io.gpio.digital.DigitalOutput;
+import com.pi4j.io.gpio.digital.DigitalState;
+import com.pi4j.plugin.mock.provider.gpio.digital.MockDigitalOutputProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class DigitalOutputOffTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(DigitalOutputOffTest.class);
+
+    private Context pi4j;
+
+    @BeforeEach
+    public void beforeTest() throws Pi4JException {
+        // Initialize Pi4J with MOCK digital output provider
+        pi4j = Pi4J.newContextBuilder().add(MockDigitalOutputProvider.newInstance()).build();
+    }
+
+    @AfterEach
+    public void afterTest() {
+        try {
+            pi4j.shutdown();
+        } catch (Pi4JException e) { /* do nothing */ }
+    }
+
+    @Test
+    public void testIsOffDefault() {
+
+        // create GPIO digital output config
+        var config  = DigitalOutput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Output")
+            .address(1)
+            .build();
+
+        // create GPIO digital output instance
+        var output = pi4j.dout().create(config);
+
+        // set output to LOW
+        output.low();
+
+        // ensure output is LOW
+        assertEquals(DigitalState.LOW, output.state());
+
+        // ensure output is OFF and not ON
+        assertTrue(output.isOff());
+        assertFalse(output.isOn());
+    }
+
+    @Test
+    public void testIsOffLow() {
+
+        // create GPIO digital output config
+        var config  = DigitalOutput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Output")
+            .address(1)
+            .onState(DigitalState.HIGH)
+            .build();
+
+        // create GPIO digital output instance
+        var output = pi4j.dout().create(config);
+
+        // set output to LOW
+        output.low();
+
+        // ensure output is LOW
+        assertEquals(DigitalState.LOW, output.state());
+
+        // ensure output is OFF and not ON
+        assertTrue(output.isOff());
+        assertFalse(output.isOn());
+    }
+
+    @Test
+    public void testIsOffHigh() {
+
+        // create GPIO digital output config
+        var config  = DigitalOutput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Output")
+            .onState(DigitalState.LOW)
+            .address(1)
+            .build();
+
+        // create GPIO digital output instance
+        var output = pi4j.dout().create(config);
+
+        // set output to HIGH
+        output.high();
+
+        // ensure output is HIGH
+        assertEquals(DigitalState.HIGH, output.state());
+
+        // ensure output is OFF and not ON
+        assertTrue(output.isOff());
+        assertFalse(output.isOn());
+    }
+
+    @Test
+    public void testOffDefault() {
+
+        // create GPIO digital output config
+        var config  = DigitalOutput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Output")
+            .address(1)
+            .build();
+
+        // create GPIO digital output instance
+        var output = pi4j.dout().create(config);
+
+        // set output to OFF
+        output.off();
+
+        // ensure output is LOW
+        assertEquals(DigitalState.LOW, output.state());
+
+        // ensure output is OFF and not ON
+        assertTrue(output.isOff());
+        assertFalse(output.isOn());
+    }
+
+    @Test
+    public void testOffHigh() {
+
+        // create GPIO digital output config
+        var config  = DigitalOutput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Output")
+            .address(1)
+            .onState(DigitalState.LOW)
+            .build();
+
+        // create GPIO digital output instance
+        var output = pi4j.dout().create(config);
+
+        // set output to OFF
+        output.off();
+
+        // ensure output is HIGH
+        assertEquals(DigitalState.HIGH, output.state());
+
+        // ensure output is OFF and not ON
+        assertTrue(output.isOff());
+        assertFalse(output.isOn());
+    }
+
+    @Test
+    public void testOffLow() {
+
+        // create GPIO digital output config
+        var config  = DigitalOutput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Output")
+            .address(1)
+            .onState(DigitalState.HIGH)
+            .build();
+
+        // create GPIO digital output instance
+        var output = pi4j.dout().create(config);
+
+        // set output to OFF
+        output.off();
+
+        // ensure output is LOW
+        assertEquals(DigitalState.LOW, output.state());
+
+        // ensure output is OFF and not ON
+        assertTrue(output.isOff());
+        assertFalse(output.isOn());
+    }
+}

--- a/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalOutputOnTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/gpio/digital/DigitalOutputOnTest.java
@@ -1,0 +1,211 @@
+package com.pi4j.test.io.gpio.digital;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: TESTING  :: Unit/Integration Tests
+ * FILENAME      :  DigitalOutputOnTest.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.pi4j.Pi4J;
+import com.pi4j.context.Context;
+import com.pi4j.exception.Pi4JException;
+import com.pi4j.io.gpio.digital.DigitalOutput;
+import com.pi4j.io.gpio.digital.DigitalState;
+import com.pi4j.plugin.mock.provider.gpio.digital.MockDigitalOutputProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class DigitalOutputOnTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(DigitalOutputOnTest.class);
+
+    private Context pi4j;
+
+    @BeforeEach
+    public void beforeTest() throws Pi4JException {
+        // Initialize Pi4J with MOCK digital output provider
+        pi4j = Pi4J.newContextBuilder().add(MockDigitalOutputProvider.newInstance()).build();
+    }
+
+    @AfterEach
+    public void afterTest() {
+        try {
+            pi4j.shutdown();
+        } catch (Pi4JException e) { /* do nothing */ }
+    }
+
+    @Test
+    public void testIsOnDefault() {
+
+        // create GPIO digital output config
+        var config  = DigitalOutput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Output")
+            .address(1)
+            .build();
+
+        // create GPIO digital output instance
+        var output = pi4j.dout().create(config);
+
+        // set output to HIGH
+        output.high();
+
+        // ensure output is HIGH
+        assertEquals(DigitalState.HIGH, output.state());
+
+        // ensure output is ON and not OFF
+        assertTrue(output.isOn());
+        assertFalse(output.isOff());
+    }
+
+    @Test
+    public void testIsOnHigh() {
+
+        // create GPIO digital output config
+        var config  = DigitalOutput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Output")
+            .address(1)
+            .onState(DigitalState.HIGH)
+            .build();
+
+        // create GPIO digital output instance
+        var output = pi4j.dout().create(config);
+
+        // set output to HIGH
+        output.high();
+
+        // ensure output is HIGH
+        assertEquals(DigitalState.HIGH, output.state());
+
+        // ensure output is ON and not OFF
+        assertTrue(output.isOn());
+        assertFalse(output.isOff());
+    }
+
+    @Test
+    public void testIsOnLow() {
+
+        // create GPIO digital output config
+        var config  = DigitalOutput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Output")
+            .onState(DigitalState.LOW)
+            .address(1)
+            .build();
+
+        // create GPIO digital output instance
+        var output = pi4j.dout().create(config);
+
+        // set output to LOW
+        output.low();
+
+        // ensure output is LOW
+        assertEquals(DigitalState.LOW, output.state());
+
+        // ensure output is ON and not OFF
+        assertTrue(output.isOn());
+        assertFalse(output.isOff());
+    }
+
+    @Test
+    public void testOnDefault() {
+
+        // create GPIO digital output config
+        var config  = DigitalOutput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Output")
+            .address(1)
+            .build();
+
+        // create GPIO digital output instance
+        var output = pi4j.dout().create(config);
+
+        // set output to ON
+        output.on();
+
+        // ensure output is HIGH
+        assertEquals(DigitalState.HIGH, output.state());
+
+        // ensure output is ON and not OFF
+        assertTrue(output.isOn());
+        assertFalse(output.isOff());
+    }
+
+    @Test
+    public void testOnHigh() {
+
+        // create GPIO digital output config
+        var config  = DigitalOutput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Output")
+            .address(1)
+            .onState(DigitalState.HIGH)
+            .build();
+
+        // create GPIO digital output instance
+        var output = pi4j.dout().create(config);
+
+        // set output to ON
+        output.on();
+
+        // ensure output is HIGH
+        assertEquals(DigitalState.HIGH, output.state());
+
+        // ensure output is ON and not OFF
+        assertTrue(output.isOn());
+        assertFalse(output.isOff());
+    }
+
+    @Test
+    public void testOnLow() {
+
+        // create GPIO digital output config
+        var config  = DigitalOutput.newConfigBuilder(pi4j)
+            .id("test-output")
+            .name("Test Digital Output")
+            .address(1)
+            .onState(DigitalState.LOW)
+            .build();
+
+        // create GPIO digital output instance
+        var output = pi4j.dout().create(config);
+
+        // set output to ON
+        output.on();
+
+        // ensure output is LOW
+        assertEquals(DigitalState.LOW, output.state());
+
+        // ensure output is ON and not OFF
+        assertTrue(output.isOn());
+        assertFalse(output.isOff());
+    }
+}

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalOutput.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalOutput.java
@@ -64,15 +64,4 @@ public class MockDigitalOutput extends DigitalOutputBase implements DigitalOutpu
         this.state(state);
         return this;
     }
-
-    @Override
-    public DigitalOutput on() throws IOException {
-        return high();
-    }
-
-    @Override
-    public DigitalOutput off() throws IOException {
-        return low();
-    }
-
 }


### PR DESCRIPTION
Adding support for configurable ON/OFF states; #93

This change allows for configuring the "**ON**" state for Digital Inputs and Outputs.

```java
        // create GPIO digital input config
        var config  = DigitalInput.newConfigBuilder(pi4j)
            .id("test-output")
            .name("Test Digital Input")
            .onState(DigitalState.HIGH).    <------------------
            .address(1)
            .build();

        // create GPIO digital input instance
        var input = pi4j.din().create(config);
```

This allows users to define if the relative term "ON" is electronically mapped to "HIGH" or "LOW states.
ON/OFF are abstract/relative concepts while HIGH and LOW are concrete signals


