### PR TITLE
No temporary memory allocation in ByteBuffer APIs.

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CRegisterDataReader.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CRegisterDataReader.java
@@ -133,22 +133,16 @@ public interface I2CRegisterDataReader {
             length = buffer.capacity()-offset;
         }
 
-        // create a temporary byte array to read in the length of data bytes
-        byte[] temp = new byte[length];
-        int actualLength = readRegister(register, temp, 0 ,length);
+        int actualLength = readRegister(register, buffer.array(), offset, length);
 
-        // return any error codes ( < 0)
+        // return any error codes (result < 0)
         if(actualLength < 0) return actualLength;
 
-        // perform bounds checking on number of bytes read versus the length requested
-        if(actualLength < length) length = actualLength;
-
         // copy the data from the temporary byte array into the return buffer at the given offset
-        buffer.position(offset);
-        buffer.put(temp, 0, length);
+        buffer.position(offset + actualLength);
 
         // return actual number of bytes read
-        return length;
+        return actualLength;
     }
 
     /**


### PR DESCRIPTION
APIs using `ByteBuffer`s are very convenient - much better than (byte[], off, len) APIs. Fortunatelly, pi4j supports such APIs, but unfortunately, it is currently not possible to create memory-efficient code using these APIs. Internally, temporary byte arrays are allocated for communication (instead of using the `ByteBuffer`s internal array). What is the reason behind this design? When communicating with devices such as gyroscopes and accelerometers a high frequency of calls are neccessary to transfer data from the device. If each call allocates temporary memory, this produces a high pressure on the PIs GC, potentially resulting in GC pauses on the device. 

I'd like to suggest to avoid allocating temporary memory whenever possible. The change in this pull-request is one example of replacing temporary memory with the internal byte array of a buffer. If such a change is welcome, I could create a more complete change.