### PR TITLE
Add new IO type and providers and interface  Sensor

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/internal/IOCreator.java
+++ b/pi4j-core/src/main/java/com/pi4j/internal/IOCreator.java
@@ -43,6 +43,9 @@ import com.pi4j.io.serial.SerialConfigBuilder;
 import com.pi4j.io.spi.Spi;
 import com.pi4j.io.spi.SpiConfig;
 import com.pi4j.io.spi.SpiConfigBuilder;
+import com.pi4j.io.sensor.Sensor;
+import com.pi4j.io.sensor.SensorConfig;
+
 
 public interface IOCreator {
 
@@ -224,5 +227,15 @@ public interface IOCreator {
      */
     default Serial create(SerialConfigBuilder config) {
         return create(config.build());
+    }
+
+    /**
+     * <p>create.</p>
+     *
+     * @param config a {@link com.pi4j.io.sensor.SensorConfig} object.
+     * @return a {@link com.pi4j.io.sensor.Sensor} object.
+     */
+    default Sensor create(SensorConfig config) {
+        return create(config, Sensor.class);
     }
 }

--- a/pi4j-core/src/main/java/com/pi4j/internal/ProviderAliases.java
+++ b/pi4j-core/src/main/java/com/pi4j/internal/ProviderAliases.java
@@ -37,6 +37,8 @@ import com.pi4j.io.spi.SpiProvider;
 import com.pi4j.provider.Provider;
 import com.pi4j.provider.exception.ProviderException;
 import com.pi4j.provider.exception.ProviderNotFoundException;
+import com.pi4j.io.sensor.SensorProvider;
+
 
 public interface ProviderAliases {
 
@@ -44,7 +46,7 @@ public interface ProviderAliases {
      * <p>provider.</p>
      *
      * @param ioType a {@link IOType} object.
-     * @param <T> a T object.
+     * @param <T>    a T object.
      * @return a T object.
      * @throws ProviderNotFoundException if any.
      */
@@ -54,11 +56,11 @@ public interface ProviderAliases {
      * <p>provider.</p>
      *
      * @param ioType a {@link IOType} object.
-     * @param <T> a T object.
+     * @param <T>    a T object.
      * @return a T object.
      * @throws ProviderNotFoundException if any.
      */
-    default <T extends Provider> T getProvider(IOType ioType) throws ProviderNotFoundException{
+    default <T extends Provider> T getProvider(IOType ioType) throws ProviderNotFoundException {
         return provider(ioType);
     }
 
@@ -81,7 +83,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends AnalogOutputProvider> T aout() throws ProviderException{
+    default <T extends AnalogOutputProvider> T aout() throws ProviderException {
         return analogOutput();
     }
 
@@ -92,7 +94,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends DigitalInputProvider> T din() throws ProviderException{
+    default <T extends DigitalInputProvider> T din() throws ProviderException {
         return digitalInput();
     }
 
@@ -103,7 +105,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends DigitalOutputProvider> T dout() throws ProviderException{
+    default <T extends DigitalOutputProvider> T dout() throws ProviderException {
         return digitalOutput();
     }
 
@@ -125,7 +127,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends AnalogOutputProvider> T analogOutput() throws ProviderException{
+    default <T extends AnalogOutputProvider> T analogOutput() throws ProviderException {
         return this.provider(IOType.ANALOG_OUTPUT);
     }
 
@@ -136,7 +138,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends DigitalInputProvider> T digitalInput() throws ProviderException{
+    default <T extends DigitalInputProvider> T digitalInput() throws ProviderException {
         return this.provider(IOType.DIGITAL_INPUT);
     }
 
@@ -147,7 +149,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends DigitalOutputProvider> T digitalOutput() throws ProviderException{
+    default <T extends DigitalOutputProvider> T digitalOutput() throws ProviderException {
         return this.provider(IOType.DIGITAL_OUTPUT);
     }
 
@@ -158,7 +160,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends PwmProvider> T pwm() throws ProviderException{
+    default <T extends PwmProvider> T pwm() throws ProviderException {
         return this.provider(IOType.PWM);
     }
 
@@ -169,7 +171,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends SpiProvider> T spi() throws ProviderException{
+    default <T extends SpiProvider> T spi() throws ProviderException {
         return this.provider(IOType.SPI);
     }
 
@@ -180,7 +182,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends I2CProvider> T i2c() throws ProviderException{
+    default <T extends I2CProvider> T i2c() throws ProviderException {
         return this.provider(IOType.I2C);
     }
 
@@ -191,7 +193,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends SerialProvider> T serial() throws ProviderException{
+    default <T extends SerialProvider> T serial() throws ProviderException {
         return this.provider(IOType.SERIAL);
     }
 
@@ -213,7 +215,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends AnalogOutputProvider> T getAnalogOutputProvider() throws ProviderException{
+    default <T extends AnalogOutputProvider> T getAnalogOutputProvider() throws ProviderException {
         return this.analogOutput();
     }
 
@@ -224,7 +226,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends DigitalInputProvider> T getDigitalInputProvider() throws ProviderException{
+    default <T extends DigitalInputProvider> T getDigitalInputProvider() throws ProviderException {
         return this.digitalInput();
     }
 
@@ -235,7 +237,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends DigitalOutputProvider> T getDigitalOutputProvider() throws ProviderException{
+    default <T extends DigitalOutputProvider> T getDigitalOutputProvider() throws ProviderException {
         return this.digitalOutput();
     }
 
@@ -246,7 +248,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends PwmProvider> T getPwmProvider() throws ProviderException{
+    default <T extends PwmProvider> T getPwmProvider() throws ProviderException {
         return this.pwm();
     }
 
@@ -257,7 +259,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends SpiProvider> T getSpiProvider() throws ProviderException{
+    default <T extends SpiProvider> T getSpiProvider() throws ProviderException {
         return this.spi();
     }
 
@@ -268,7 +270,7 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends I2CProvider> T getI2CProvider() throws ProviderException{
+    default <T extends I2CProvider> T getI2CProvider() throws ProviderException {
         return this.i2c();
     }
 
@@ -279,7 +281,32 @@ public interface ProviderAliases {
      * @return a T object.
      * @throws ProviderException if any.
      */
-    default <T extends SerialProvider> T getSerialProvider() throws ProviderException{
+    default <T extends SerialProvider> T getSerialProvider() throws ProviderException {
         return this.serial();
     }
+
+
+    /**
+     * <p>sensor.</p>
+     *
+     * @param <T> a T object.
+     * @return a T object.
+     * @throws ProviderException if any.
+     */
+    default <T extends SensorProvider> T sensor() throws ProviderException {
+        return this.provider(IOType.SENSOR);
+    }
+
+
+    /**
+     * <p>serial.</p>
+     *
+     * @param <T> a T object.
+     * @return a T object.
+     * @throws ProviderException if any.
+     */
+    default <T extends SensorProvider> T getSensorProvider() throws ProviderException {
+        return this.sensor();
+    }
 }
+

--- a/pi4j-core/src/main/java/com/pi4j/io/IOType.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOType.java
@@ -36,6 +36,10 @@ import com.pi4j.io.pwm.Pwm;
 import com.pi4j.io.pwm.PwmConfig;
 import com.pi4j.io.pwm.PwmConfigBuilder;
 import com.pi4j.io.pwm.PwmProvider;
+import com.pi4j.io.sensor.Sensor;
+import com.pi4j.io.sensor.SensorConfig;
+import com.pi4j.io.sensor.SensorConfigBuilder;
+import com.pi4j.io.sensor.SensorProvider;
 import com.pi4j.io.serial.Serial;
 import com.pi4j.io.serial.SerialConfig;
 import com.pi4j.io.serial.SerialConfigBuilder;
@@ -61,7 +65,8 @@ public enum IOType {
     PWM(PwmProvider.class, Pwm.class, PwmConfig.class, PwmConfigBuilder.class),
     I2C(I2CProvider.class, com.pi4j.io.i2c.I2C.class, I2CConfig.class, I2CConfigBuilder.class),
     SPI(SpiProvider.class, Spi.class, I2CConfig.class, I2CConfigBuilder.class),
-    SERIAL(SerialProvider.class, Serial.class, SerialConfig.class, SerialConfigBuilder.class);
+    SERIAL(SerialProvider.class, Serial.class, SerialConfig.class, SerialConfigBuilder.class),
+    SENSOR(SensorProvider.class, Sensor.class, SensorConfig.class, SensorConfigBuilder .class);
 
     private Class<? extends Provider> providerClass;
     private Class<? extends IO> ioClass;
@@ -336,6 +341,9 @@ public enum IOType {
         if(ioType.equalsIgnoreCase("uart")) return SERIAL;
         if(ioType.equalsIgnoreCase("rs232")) return SERIAL;
 
+        // SENSOR
+        if(ioType.startsWith("sensor")) return SENSOR;
+        if(ioType.equalsIgnoreCase("sensor")) return SENSOR;
 
         throw new IllegalArgumentException("Unknown IO TYPE: " + ioType);
     }

--- a/pi4j-core/src/main/java/com/pi4j/io/sensor/Sensor.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/sensor/Sensor.java
@@ -1,0 +1,101 @@
+package com.pi4j.io.sensor;
+
+/*
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: LIBRARY  :: Java Library (CORE)
+ * FILENAME      :  Sensor.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import com.pi4j.context.Context;
+import com.pi4j.io.IO;
+
+/**
+ * <p>Sensor interface.</p>
+ *
+ * @author Tom Aarts
+ * @version $Id: $Id
+ */
+public interface Sensor extends IO<Sensor, SensorConfig, SensorProvider> {
+
+
+    int DEFAULT_BUS = 1;
+    int DEFAULT_ADDRESS = 0x76;
+
+    /**
+     * <p>newConfigBuilder.</p>
+     *
+     * @param context {@link Context}
+     * @return a {@link com.pi4j.io.sensor.SensorConfigBuilder} object.
+     */
+    static SensorConfigBuilder newConfigBuilder(Context context) {
+        return SensorConfigBuilder.newInstance(context);
+    }
+
+
+    /**
+     * Perform any/all actions to reset the sensor
+     */
+    default void resetSensor() {
+    }
+
+    /**
+     * Perform any/all actions to initialize  the sensor
+     */
+    default void initSensor() {
+    }
+
+    /*** @return temperature in centigrade
+     */
+    default double temperatureC() {
+        return 0;
+    }
+
+    /** @return temperature in fahrenheit
+     */
+    default double temperatureF() {
+        return 0;
+    }
+
+
+    /**
+     * @return presure in Pa units
+     */
+    default double pressurePa() {
+        return 0;
+    }
+
+    /**
+     * @return pressure in Inches Mercury
+     */
+    default double pressureIn() {
+        return 0;
+    }
+
+    /**
+     * @return pressure in millibar
+     */
+    default double pressureMb() {
+        return 0;
+    }
+
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/sensor/SensorBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/sensor/SensorBase.java
@@ -1,0 +1,53 @@
+package com.pi4j.io.sensor;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: LIBRARY  :: Java Library (CORE)
+ * FILENAME      :  SensorBase.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.pi4j.io.IOBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>Abstract SensorBase class.</p>
+ *
+ * @author Tom Aarts
+ * @version $Id: $Id
+ */
+public abstract class SensorBase extends IOBase<Sensor, SensorConfig, SensorProvider> implements Sensor {
+
+    Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    /**
+     * <p>Constructor for SensorBase.</p>
+     *
+     * @param provider a {@link com.pi4j.io.sensor.SensorProvider} object.
+     * @param config   a {@link com.pi4j.io.sensor.SensorConfig} object.
+     */
+    public SensorBase(SensorProvider provider, SensorConfig config) {
+        super(provider, config);
+    }
+
+
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/sensor/SensorConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/sensor/SensorConfig.java
@@ -1,0 +1,96 @@
+package com.pi4j.io.sensor;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: LIBRARY  :: Java Library (CORE)
+ * FILENAME      :  SensorConfig.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.pi4j.config.AddressConfig;
+import com.pi4j.context.Context;
+import com.pi4j.io.IOConfig;
+
+/**
+ * <p>SensorConfig interface.</p>
+ *
+ * @author Tom Aarts
+ * @version $Id: $Id
+ */
+//AddressConfig<SensorConfig>,
+public interface SensorConfig extends IOConfig<SensorConfig>, AddressConfig<SensorConfig> {
+
+
+    /**
+     * Constant <code>BUS_KEY="bus"</code>
+     */
+    String BUS_KEY = "bus";
+    /**
+     * Constant <code>ADDRESS_KEY="addressmode"</code>
+     */
+    String ADDRESS_KEY = "address";
+
+
+    /**
+     * <p>newBuilder.</p>
+     *
+     * @param context {@link Context}
+     * @return a {@link com.pi4j.io.i2c.I2CConfigBuilder} object.
+     */
+    static SensorConfigBuilder newBuilder(Context context) {
+        return SensorConfigBuilder.newInstance(context);
+    }
+
+
+    /**
+     * <p>bus.</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    Integer bus();
+
+    /**
+     * <p>getBus.</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    default Integer getBus() {
+        return bus();
+    }
+
+
+    /**
+     * <p>address.</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    Integer address();
+
+    /**
+     * <p>getMode.</p>
+     *
+     * @return a {@link java.lang.Integer} object.
+     */
+    default Integer getAddress() {
+        return address();
+    }
+
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/sensor/SensorConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/sensor/SensorConfigBuilder.java
@@ -1,0 +1,69 @@
+package com.pi4j.io.sensor;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: LIBRARY  :: Java Library (CORE)
+ * FILENAME      :  SensorConfigBuilder.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.pi4j.config.ConfigBuilder;
+import com.pi4j.context.Context;
+import com.pi4j.io.IOConfigBuilder;
+import com.pi4j.io.sensor.impl.DefaultSensorConfigBuilder;
+
+/**
+ * <p>SensorConfigBuilder interface.</p>
+ *
+ * @author  Tom Aarts
+ * @version $Id: $Id
+ */
+public interface SensorConfigBuilder extends IOConfigBuilder<SensorConfigBuilder, SensorConfig>,
+    ConfigBuilder<SensorConfigBuilder, SensorConfig> {
+    /**
+     * <p>newInstance.</p>
+     *
+     * @param context {@link Context}
+     * @return a {@link com.pi4j.io.sensor.SensorConfigBuilder} object.
+     */
+    static SensorConfigBuilder newInstance(Context context) {
+        return DefaultSensorConfigBuilder.newInstance(context);
+    }
+
+
+    /**
+     * <p>address.</p>
+     *
+     * @param address a {@link java.lang.Integer} object.
+     * @return a {@link com.pi4j.io.sensor.SensorConfigBuilder} object.
+     */
+    SensorConfigBuilder address(Integer address);
+
+    /**
+     * <p>bus.</p>
+     *
+     * @param bus a {@link java.lang.Integer} object.
+     * @return a {@link com.pi4j.io.sensor.SensorConfigBuilder} object.
+     */
+    SensorConfigBuilder bus(Integer bus);
+
+
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/sensor/SensorProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/sensor/SensorProvider.java
@@ -1,0 +1,75 @@
+package com.pi4j.io.sensor;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: LIBRARY  :: Java Library (CORE)
+ * FILENAME      :  SensorProvider.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import com.pi4j.provider.Provider;
+
+/**
+ * <p>SensorProvider interface.</p>
+ *
+ * @author  Tom Aarts
+ * @version $Id: $Id
+ */
+public interface SensorProvider extends Provider<SensorProvider, Sensor, SensorConfig> {
+
+
+    default <T extends Sensor> T create(SensorConfigBuilder builder) {
+        return (T) create(builder.build());
+    }
+
+    default <T extends Sensor> T create(Integer address) {
+        var config = Sensor.newConfigBuilder(context())
+            .build();
+        return (T) create(config);
+    }
+
+    default <T extends Sensor> T create(Integer address, String id) {
+        var config = Sensor.newConfigBuilder(context())
+            .address(address)
+            .id(id)
+            .build();
+        return (T) create(config);
+    }
+
+    default <T extends Sensor> T create(Integer address, String id, String name) {
+        var config = Sensor.newConfigBuilder(context())
+            .id(id)
+            .name(name)
+            .build();
+        return (T) create(config);
+    }
+
+    default <T extends Sensor> T create(Integer address, String id, String name, String description) {
+        var config = Sensor.newConfigBuilder(context())
+            .id(id)
+            .name(name)
+            .description(description)
+            .build();
+        return (T) create(config);
+    }
+
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/sensor/SensorProviderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/sensor/SensorProviderBase.java
@@ -1,0 +1,65 @@
+package com.pi4j.io.sensor;
+
+import com.pi4j.provider.ProviderBase;
+
+/*
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: LIBRARY  :: Java Library (CORE)
+ * FILENAME      :  SensorProviderBase.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ * <p>Abstract SensorProviderBase class.</p>
+ *
+ * @author  Tom Aarts
+ * @version $Id: $Id
+ */
+public abstract class SensorProviderBase
+    extends ProviderBase<SensorProvider, Sensor, SensorConfig>
+    implements SensorProvider {
+
+    /**
+     * <p>Constructor for SensorProviderBase.</p>
+     */
+    public SensorProviderBase() {
+        super();
+    }
+
+    /**
+     * <p>Constructor for SensorProviderBase.</p>
+     *
+     * @param id a {@link java.lang.String} object.
+     */
+    public SensorProviderBase(String id) {
+        super(id);
+    }
+
+    /**
+     * <p>Constructor for SensorProviderBase.</p>
+     *
+     * @param id   a {@link java.lang.String} object.
+     * @param name a {@link java.lang.String} object.
+     */
+    public SensorProviderBase(String id, String name) {
+        super(id, name);
+    }
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/sensor/impl/DefaultSensorConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/sensor/impl/DefaultSensorConfig.java
@@ -1,0 +1,95 @@
+package com.pi4j.io.sensor.impl;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: LIBRARY  :: Java Library (CORE)
+ * FILENAME      :  DefaultSensorConfig.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.pi4j.io.impl.IOConfigBase;
+import com.pi4j.io.sensor.Sensor;
+import com.pi4j.io.sensor.SensorConfig;
+import com.pi4j.util.StringUtil;
+
+import java.util.Map;
+
+/**
+ * <p>DefaultSensorConfig class.</p>
+ *
+ * @author  Tom Aarts
+ * @version $Id: $Id
+ */
+// extends IOAddressConfigBase<SensorConfig>
+//
+public class DefaultSensorConfig
+    extends IOConfigBase<SensorConfig>
+    implements SensorConfig {
+
+    // private configuration properties
+
+    protected final Integer bus;
+    protected final Integer address;
+
+    /**
+     * PRIVATE CONSTRUCTOR
+     *
+     * @param properties a {@link java.util.Map} object.
+     */
+    protected DefaultSensorConfig(Map<String, String> properties) {
+        super(properties);
+
+
+        if (properties.containsKey(BUS_KEY)) {
+            this.bus = StringUtil.parseInteger(properties.get(BUS_KEY), Sensor.DEFAULT_BUS);
+        } else {
+            this.bus = Sensor.DEFAULT_BUS;
+        }
+
+
+        if (properties.containsKey(SensorConfig.ADDRESS_KEY)) {
+            this.address = StringUtil.parseInteger(properties.get(SensorConfig.ADDRESS_KEY), Sensor.DEFAULT_ADDRESS);
+        } else {
+            this.address = Sensor.DEFAULT_ADDRESS;
+        }
+
+        // define default property values if any are missing (based on the required address value)
+        this.id = StringUtil.setIfNullOrEmpty(this.id, "SENSOR-" + this.address(), true);
+        this.name = StringUtil.setIfNullOrEmpty(this.name, "SENSOR-" + this.address(), true);
+        this.description = StringUtil.setIfNullOrEmpty(this.description, "SENSOR-" + this.address(), true);
+    }
+
+
+    @Override
+    public Integer bus() {
+        return this.bus;
+    }
+
+    @Override
+    public Integer address() {
+        return this.address;
+    }
+
+    @Override
+    public Integer getAddress() {
+        return this.address;
+    }
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/sensor/impl/DefaultSensorConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/sensor/impl/DefaultSensorConfigBuilder.java
@@ -1,0 +1,87 @@
+package com.pi4j.io.sensor.impl;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: LIBRARY  :: Java Library (CORE)
+ * FILENAME      :  DefaultSensorConfigBuilder.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.pi4j.context.Context;
+import com.pi4j.io.impl.IOConfigBuilderBase;
+import com.pi4j.io.sensor.SensorConfig;
+import com.pi4j.io.sensor.SensorConfigBuilder;
+
+/**
+ * <p>DefaultSensorConfigBuilder class.</p>
+ *
+ * @author  Tom Aarts
+ * @version $Id: $Id
+ */
+public class DefaultSensorConfigBuilder
+    extends IOConfigBuilderBase<SensorConfigBuilder, SensorConfig>
+    implements SensorConfigBuilder {
+
+    /**
+     * PRIVATE CONSTRUCTOR
+     */
+    protected DefaultSensorConfigBuilder(Context context) {
+        super(context);
+    }
+
+    /**
+     * <p>newInstance.</p>
+     *
+     * @return a {@link com.pi4j.io.sensor.SensorConfigBuilder} object.
+     */
+    public static SensorConfigBuilder newInstance(Context context) {
+        return new DefaultSensorConfigBuilder(context);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SensorConfigBuilder bus(Integer bus) {
+        this.properties.put(SensorConfig.BUS_KEY, bus.toString());
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SensorConfigBuilder address(Integer address) {
+        this.properties.put(SensorConfig.ADDRESS_KEY, address.toString());
+        return this;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SensorConfig build() {
+        SensorConfig config = new DefaultSensorConfig(this.properties);
+        return config;
+    }
+}

--- a/pi4j-core/src/main/java/module-info.java
+++ b/pi4j-core/src/main/java/module-info.java
@@ -54,6 +54,10 @@ module com.pi4j {
     exports com.pi4j.registry;
     exports com.pi4j.util;
 
+
+    // new sensor provider
+    exports com.pi4j.io.sensor;
+
     // extensibility service interfaces
     uses com.pi4j.extension.Plugin;
 }


### PR DESCRIPTION
This add support into the pi4j-core.  It is a new IO type  Sensor. also defines an interface Sensor, Config/builder and provider.

There exist https://github.com/taartspi/Pi4J_V2-TemperatureSensor      This implements an I2C device that uses a BMP280 sensor, requiring this branch.  This branch also documents connecting an Adafruit BMP280 to a Pi.