### PR TITLE
Add java_doc to make debounce default visible on input gpio config bu…

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalInputConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalInputConfigBuilder.java
@@ -50,8 +50,10 @@ public interface DigitalInputConfigBuilder extends DigitalConfigBuilder<DigitalI
      *
      * @param microseconds a {@link java.lang.Long} object.
      * @return a {@link com.pi4j.io.gpio.digital.DigitalInputConfigBuilder} object.
+     * @see com.pi4j.io.gpio.digital.DigitalInput#DEFAULT_DEBOUNCE DEFAULT_DEBOUNCE
      */
     DigitalInputConfigBuilder debounce(Long microseconds);
+   
     /**
      * <p>debounce.</p>
      *


### PR DESCRIPTION
In debugging missed interrupts from a chip I realized the GPIO input debounce default value was greater than the chips interrupt duration.  This is just an added line of javadoc so the default details are available when hovering over the debounce() method when :    
DigitalInput.newConfigBuilder(pi4j)   
      .debounce()    
