### PR TITLE
The spi provider docs states mode 1 and 2 are not supported on the sec…

### DIFF
--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/spi/PiGpioSpi.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/spi/PiGpioSpi.java
@@ -113,7 +113,7 @@ public class PiGpioSpi extends SpiBase implements Spi {
         }
 
         // SPI MODE_1 and MODE_2 are not supported on the AUX SPI BUS_1 by PiGPIO
-        if(bus == SpiBus.BUS_0 && (mode == SpiMode.MODE_1 || mode == SpiMode.MODE_3)) {
+        if(bus == SpiBus.BUS_1 && (mode == SpiMode.MODE_1 || mode == SpiMode.MODE_3)) {
             throw new IOException("Unsupported SPI mode on AUX SPI BUS_1: mode=" + mode.toString());
         }
 


### PR DESCRIPTION
The spi provider docs states mode 1 and 2 are not supported on the secondary spi.  The test was not correct and it prevented mode 1 on spi0

The only testing I did was to validate I can communicate to my spi device mode 1 from spi0.

if there is other testing you have that I can/should run, point me to the tests.