### PR TITLE
since no unique except thrown with ELF32/ELF64 violation. Examine err…

### DIFF
--- a/libraries/pi4j-library-linuxfs/src/main/java/com/pi4j/library/linuxfs/util/NativeLibraryLoader.java
+++ b/libraries/pi4j-library-linuxfs/src/main/java/com/pi4j/library/linuxfs/util/NativeLibraryLoader.java
@@ -123,14 +123,31 @@ public class NativeLibraryLoader {
                 try {
                     // load library from user defined absolute path provided via pi4j.library.path}
                     System.load(path);
-                }
-                catch (Exception ex){
-                    //throw this error
-                    throw new UnsatisfiedLinkError("Pi4J was unable load the native library [" +
-                        libName + "] from the user defined library path.  The system property 'pi4j.library.path' is defined as [" +
-                        libpath + "]. Please make sure the defined the 'pi4j.library.path' " +
-                        "system property contains the correct absolute library path." +
-                        "; UNDERLYING EXCEPTION: [" + ex.getClass().getName() + "]=" + ex.getMessage());
+                } catch (UnsatisfiedLinkError ex) {
+                    String exceptMessage;
+                    // no guarantee the except pertains to ELF miss-match so check MSG content
+                    if (ex.getMessage().contains("wrong ELF class")) {
+                        exceptMessage = "Pi4J was unable to link the native library [" +
+                            path + "] embedded  inside this JAR [" +
+                            NativeLibraryLoader.class.getProtectionDomain().getCodeSource().getLocation().getPath() +
+                            "].  The exception indicates a mismatch of architecture. armhf/ELFCLASS32 aarch64/ELFCLASS64 \n" +
+                            " UNDERLYING EXCEPTION: [" + ex.getClass().getName() + "]=" + ex.getMessage();
+                    } else {
+                        exceptMessage = "Pi4J was unable to extract and load the native library [" +
+                            path + "] from the embedded resources inside this JAR [" +
+                            NativeLibraryLoader.class.getProtectionDomain().getCodeSource().getLocation().getPath() +
+                            "]. to a temporary location on this system.  You can alternatively define the 'pi4j.library.path' " +
+                            "system property to override this behavior and specify the library path.\n" +
+                            " UNDERLYING EXCEPTION: [" + ex.getClass().getName() + "]=" + ex.getMessage();
+                    }
+                    throw new UnsatisfiedLinkError(exceptMessage);
+                } catch (Exception ex) {
+                    throw new UnsatisfiedLinkError("Pi4J was unable to extract and load the native library [" +
+                        path + "] from the embedded resources inside this JAR [" +
+                        NativeLibraryLoader.class.getProtectionDomain().getCodeSource().getLocation().getPath() +
+                        "]. to a temporary location on this system.  You can alternatively define the 'pi4j.library.path' " +
+                        "system property to override this behavior and specify the library path.\n" +
+                        " UNDERLYING EXCEPTION: [" + ex.getClass().getName() + "]=" + ex.getMessage());
                 }
             }
         }
@@ -161,22 +178,41 @@ public class NativeLibraryLoader {
             try {
                 loadLibraryFromClasspath(path);
                 logger.debug("Library [" + fileName + "] loaded successfully using embedded resource file: [" + path + "]");
-            } catch (Exception | UnsatisfiedLinkError e) {
+            } catch (UnsatisfiedLinkError e) {
                 logger.error("Unable to load [" + fileName + "] using path: [" + path + "]", e);
-
-                //throw this error
+                String exceptMessage;
+                // no guarantee the except pertains to ELF miss-match so check MSG content
+                if (e.getMessage().contains("wrong ELF class")) {
+                    exceptMessage = "Pi4J was unable to link the native library [" +
+                        path + "] embedded  inside this JAR [" +
+                        NativeLibraryLoader.class.getProtectionDomain().getCodeSource().getLocation().getPath() +
+                        "].  The exception indicates a mismatch of architecture. armhf/ELFCLASS32 aarch64/ELFCLASS64 \n" +
+                        " All native libraries must be of architecture " + osArch + " \n" +
+                        " UNDERLYING EXCEPTION: [" + e.getClass().getName() + "]=" + e.getMessage();
+                } else {
+                    exceptMessage = "Pi4J was unable to extract and load the native library [" +
+                        path + "] from the embedded resources inside this JAR [" +
+                        NativeLibraryLoader.class.getProtectionDomain().getCodeSource().getLocation().getPath() +
+                        "]. to a temporary location on this system.  You can alternatively define the 'pi4j.library.path' " +
+                        "system property to override this behavior and specify the library path.\n" +
+                        " UNDERLYING EXCEPTION: [" + e.getClass().getName() + "]=" + e.getMessage();
+                }
+                throw new UnsatisfiedLinkError(exceptMessage);
+            } catch (Exception e) {
+                logger.error("Unable to load [" + fileName + "] using path: [" + path + "]", e);
                 throw new UnsatisfiedLinkError("Pi4J was unable to extract and load the native library [" +
                     path + "] from the embedded resources inside this JAR [" +
                     NativeLibraryLoader.class.getProtectionDomain().getCodeSource().getLocation().getPath() +
                     "]. to a temporary location on this system.  You can alternatively define the 'pi4j.library.path' " +
-                    "system property to override this behavior and specify the library path.");
+                    "system property to override this behavior and specify the library path.\n" +
+                    " UNDERLYING EXCEPTION: [" + e.getClass().getName() + "]=" + e.getMessage());
             }
         }
 	}
 
 	/**
 	 * Loads library from classpath
-	 *
+     *
 	 * The file from classpath is copied into system temporary directory and then loaded. The temporary file is
      * deleted after exiting. Method uses String as filename because the pathname is
 	 * "abstract", not system-dependent.

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/util/NativeLibraryLoader.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/util/NativeLibraryLoader.java
@@ -105,6 +105,7 @@ public class NativeLibraryLoader {
                     // load library from local path of this JAR file
                     System.load(path);
                 }
+
                 catch (Exception ex){
                     //throw this error
                     throw new UnsatisfiedLinkError("Pi4J was unable load the native library [" +
@@ -123,14 +124,33 @@ public class NativeLibraryLoader {
                 try {
                     // load library from user defined absolute path provided via pi4j.library.path}
                     System.load(path);
-                }
-                catch (Exception ex){
-                    //throw this error
-                    throw new UnsatisfiedLinkError("Pi4J was unable load the native library [" +
-                        libName + "] from the user defined library path.  The system property 'pi4j.library.path' is defined as [" +
-                        libpath + "]. Please make sure the defined the 'pi4j.library.path' " +
-                        "system property contains the correct absolute library path." +
-                        "; UNDERLYING EXCEPTION: [" + ex.getClass().getName() + "]=" + ex.getMessage());
+                } catch (UnsatisfiedLinkError ex) {
+                    logger.error("Unable to load/link [" + fileName + "] using path: [" + path + "]", ex);
+                    String exceptMessage;
+                    // no guarantee the except pertains to ELF miss-match so check MSG content
+                    if (ex.getMessage().contains("wrong ELF class")) {
+                        exceptMessage = "Pi4J was unable to link the native library [" +
+                            path + "] embedded  inside this JAR [" +
+                            NativeLibraryLoader.class.getProtectionDomain().getCodeSource().getLocation().getPath() +
+                            "].  The exception indicates a mismatch of architecture. armhf/ELFCLASS32 aarch64/ELFCLASS64 \n" +
+                            " UNDERLYING EXCEPTION: [" + ex.getClass().getName() + "]=" + ex.getMessage();
+                    } else {
+                        exceptMessage = "Pi4J was unable to extract and load the native library [" +
+                            path + "] from the embedded resources inside this JAR [" +
+                            NativeLibraryLoader.class.getProtectionDomain().getCodeSource().getLocation().getPath() +
+                            "]. to a temporary location on this system.  You can alternatively define the 'pi4j.library.path' " +
+                            "system property to override this behavior and specify the library path.\n" +
+                            " UNDERLYING EXCEPTION: [" + ex.getClass().getName() + "]=" + ex.getMessage();
+                    }
+                    throw new UnsatisfiedLinkError(exceptMessage);
+                } catch (Exception ex) {
+                    logger.error("Unable to load/link [" + fileName + "] using path: [" + path + "]", ex);
+                    throw new UnsatisfiedLinkError("Pi4J was unable to extract and load the native library [" +
+                        path + "] from the embedded resources inside this JAR [" +
+                        NativeLibraryLoader.class.getProtectionDomain().getCodeSource().getLocation().getPath() +
+                        "]. to a temporary location on this system.  You can alternatively define the 'pi4j.library.path' " +
+                        "system property to override this behavior and specify the library path.\n" +
+                        " UNDERLYING EXCEPTION: [" + ex.getClass().getName() + "]=" + ex.getMessage());
                 }
             }
         }
@@ -161,15 +181,34 @@ public class NativeLibraryLoader {
             try {
                 loadLibraryFromClasspath(path);
                 logger.debug("Library [" + fileName + "] loaded successfully using embedded resource file: [" + path + "]");
-            } catch (Exception | UnsatisfiedLinkError e) {
-                logger.error("Unable to load [" + fileName + "] using path: [" + path + "]", e);
-
-                //throw this error
+            } catch (UnsatisfiedLinkError e) {
+                logger.error("Unable to load/link [" + fileName + "] using path: [" + path + "]", e);
+                String exceptMessage;
+                // no guarantee the except pertains to ELF miss-match so check MSG content
+                if (e.getMessage().contains("wrong ELF class")) {
+                    exceptMessage = "Pi4J was unable to link the native library [" +
+                        path + "] embedded  inside this JAR [" +
+                        NativeLibraryLoader.class.getProtectionDomain().getCodeSource().getLocation().getPath() +
+                        "].  The exception indicates a mismatch of architecture. armhf/ELFCLASS32 aarch64/ELFCLASS64 \n" +
+                        " All native libraries must be of architecture " + osArch + " \n" +
+                        " UNDERLYING EXCEPTION: [" + e.getClass().getName() + "]=" + e.getMessage();
+                } else {
+                    exceptMessage = "Pi4J was unable to extract and load the native library [" +
+                        path + "] from the embedded resources inside this JAR [" +
+                        NativeLibraryLoader.class.getProtectionDomain().getCodeSource().getLocation().getPath() +
+                        "]. to a temporary location on this system.  You can alternatively define the 'pi4j.library.path' " +
+                        "system property to override this behavior and specify the library path.\n" +
+                        " UNDERLYING EXCEPTION: [" + e.getClass().getName() + "]=" + e.getMessage();
+                }
+                throw new UnsatisfiedLinkError(exceptMessage);
+            } catch (IOException e) {
+                logger.error("Unable to load/link [" + fileName + "] using path: [" + path + "]", e);
                 throw new UnsatisfiedLinkError("Pi4J was unable to extract and load the native library [" +
                     path + "] from the embedded resources inside this JAR [" +
                     NativeLibraryLoader.class.getProtectionDomain().getCodeSource().getLocation().getPath() +
                     "]. to a temporary location on this system.  You can alternatively define the 'pi4j.library.path' " +
-                    "system property to override this behavior and specify the library path.");
+                    "system property to override this behavior and specify the library path.\n" +
+                    " UNDERLYING EXCEPTION: [" + e.getClass().getName() + "]=" + e.getMessage());
             }
         }
 	}


### PR DESCRIPTION
…or message for wrong ELF class. If found in except data throw detailed message to try and inform the user of the error. Change in normal and pi4j.library.path set to library location.