### PR TITLE
track weather the user set the mode or bus config values. If they did…

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/spi/SpiConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/SpiConfig.java
@@ -69,13 +69,16 @@ public interface SpiConfig extends AddressConfig<SpiConfig>, IOConfig<SpiConfig>
     default Integer getBaud() { return baud(); }
 
     /**
-     * <p>mode.</p>
+     * <p>bus.</p>
+     * <p>If the Bus value is configured, that SpiBus
+     * value will be set in the flags {@link #flags()}   bit 'A' 8
+     * </p>
      *
      * @return a {@link com.pi4j.io.spi.SpiBus} object.
      */
     SpiBus bus();
     /**
-     * <p>getMode.</p>
+     * <p>getBus.</p>
      *
      * @return a {@link com.pi4j.io.spi.SpiBus} object.
      */
@@ -84,7 +87,25 @@ public interface SpiConfig extends AddressConfig<SpiConfig>, IOConfig<SpiConfig>
     }
 
     /**
+     * <p>busUserProvided.</p>
+     * @return  a boolean.
+     */
+    boolean busUserProvided();
+
+    /**
+     * <p>getBusUserProvided.</p>
+     * @return  a {@link java.lang.Boolean} object.
+     */
+    default boolean getBusUserProvided(){
+        return busUserProvided();
+    }
+
+
+    /**
      * <p>mode.</p>
+     * <p>If the Mode value is configured, that SpiMode
+     * value will be set in the flags  {@link #mode()}  bit 'm m' 1:0
+     * </p>
      *
      * @return a {@link com.pi4j.io.spi.SpiMode} object.
      */
@@ -96,6 +117,20 @@ public interface SpiConfig extends AddressConfig<SpiConfig>, IOConfig<SpiConfig>
      */
     default SpiMode getMode() {
         return mode();
+    }
+
+    /**
+     * <p>modeUserProvided.</p>
+     * @return  a boolean.
+     */
+    boolean modeUserProvided();
+
+    /**
+     * <p>bgetModeUserProvided.</p>
+     * @return  a {@link java.lang.Boolean} object.
+     */
+    default boolean getModeUserProvided(){
+        return modeUserProvided();
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/SpiConfigBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/SpiConfigBuilder.java
@@ -57,7 +57,9 @@ public interface SpiConfigBuilder extends
 
     /**
      * <p>bus.</p>
-     *
+     * <p>If the Bus value is configured, that SpiBus
+     * value will be set in the flags {@link #flags(Long)}   bit 'A' 8
+     * </p>
      * @param bus a {@link com.pi4j.io.spi.SpiBus} object.
      * @return a {@link com.pi4j.io.spi.SpiConfigBuilder} object.
      */
@@ -73,6 +75,9 @@ public interface SpiConfigBuilder extends
 
     /**
      * <p>mode.</p>
+     *<p>If the Mode value is configured, that SpiMode
+     * value will be set in the flags  {@link #flags(Long)}  bit 'm m' 1:0
+     * </p>
      *
      * @param mode a {@link com.pi4j.io.spi.SpiMode} object.
      * @return a {@link com.pi4j.io.spi.SpiConfigBuilder} object.

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/impl/DefaultSpiConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/impl/DefaultSpiConfig.java
@@ -44,7 +44,9 @@ public class DefaultSpiConfig
     // private configuration properties
     protected final Integer baud;
     protected final SpiMode mode;
+    protected boolean modeUserProvided = false;  // indicate user supplied the value
     protected final SpiBus bus;
+    protected boolean busUserProvided = false;  // indicate user supplied the value
     protected final Long flags;
 
     /**
@@ -65,15 +67,19 @@ public class DefaultSpiConfig
         // load optional BUS from properties
         if(properties.containsKey(BUS_KEY)){
             this.bus = SpiBus.parse(properties.get(BUS_KEY));
+            this.busUserProvided = true;
         } else {
             this.bus = Spi.DEFAULT_BUS;
+            this.busUserProvided = false;
         }
 
         // load optional MODE from properties
         if(properties.containsKey(MODE_KEY)){
             this.mode = SpiMode.parse(properties.get(MODE_KEY));
+            this.modeUserProvided = true;
         } else {
             this.mode = Spi.DEFAULT_MODE;
+            this.modeUserProvided = false;
         }
 
         // load optional FLAGS BITS from properties
@@ -93,6 +99,21 @@ public class DefaultSpiConfig
     @Override
     public Integer baud() {
         return this.baud;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean busUserProvided() {
+        return this.busUserProvided;
+    }
+
+
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean modeUserProvided()
+    {
+        return this.modeUserProvided;
     }
 
     /** {@inheritDoc} */

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/spi/PiGpioSpi.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/spi/PiGpioSpi.java
@@ -119,25 +119,28 @@ public class PiGpioSpi extends SpiBase implements Spi {
             throw new IOException("Unsupported SPI mode on AUX SPI BUS_1: mode=" + mode.toString());
         }
 
-        // update flags value with BUS bit ('A' 0x0000=BUS0; 0x0100=BUS1)
-        if(bus == SpiBus.BUS_0) {
-            flags = (flags & (0xFFFFFFFF ^ SPI_BUS_MASK)); // clear AUX bit
+
+        if(config.busUserProvided()) {  // user provided, overwrite flags
+            // update flags value with BUS bit ('A' 0x0000=BUS0; 0x0100=BUS1)
+            if (bus == SpiBus.BUS_0) {
+                flags = (flags & (0xFFFFFFFF ^ SPI_BUS_MASK)); // clear AUX bit
+            } else if (bus == SpiBus.BUS_1) {
+                flags = (flags & (0xFFFFFFFF ^ SPI_BUS_MASK)) | SPI_BUS_MASK; // set AUX bit
+            }
         }
-        else if(bus == SpiBus.BUS_1) {
-            flags = (flags & (0xFFFFFFFF ^ SPI_BUS_MASK)) | SPI_BUS_MASK; // set AUX bit
+
+        if(config.modeUserProvided()) {  // user provided, overwrite flags
+            // update flags value with MODE bits ('mm' 0x03)
+            flags = (flags & (0xFFFFFFFF ^ SPI_MODE_MASK)) | mode.getMode(); // set MODE bits
         }
+            // create SPI instance of PiGPIO SPI
+       this.handle = piGpio.spiOpen(
+            config.address(),
+            config.baud(),
+            flags);
 
-        // update flags value with MODE bits ('mm' 0x03)
-        flags = (flags & (0xFFFFFFFF ^ SPI_MODE_MASK)) | mode.getMode(); // set MODE bits
-
-        // create SPI instance of PiGPIO SPI
-        this.handle = piGpio.spiOpen(
-                config.address(),
-                config.baud(),
-                flags);
-
-        // set open state flag
-        this.isOpen = true;
+       // set open state flag
+       this.isOpen = true;
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Track weather the user set the mode and/or bus config values. If they supplied mode update flag  with the supplied value, if they supplied bus  update the flag with the supplied value. If no user supplied  mode skip flag update, no user supplied bus skip flag update.

 As the default value of mode and bus are both zero and the flags if not user supplied init value is zero, this will not alter the previous result when no user mode or bus was user supplied.

I reviewed the other providers and SPI is the only one that modifies the user provided config values.  I saw two ways to changes this, make the mode and bus required, or decided upon when to update the flags based on whether the user supplied mode and/or bus.  I choose the update based on user provided config data.

If what I did seems too difficult to explain in a point release README it would be few changes to make the mode and bus required,  and that is an easy explanation in the README
