### PR TITLE
Improve the readability of PiGpioNativeImpl#gpioInitialise and make it more robust

### DIFF
--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpioConst.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpioConst.java
@@ -414,4 +414,12 @@ public interface PiGpioConst {
     int SIGTERM = 15;
     int SIGSTOP = 19;
     int SIGTSTP = 20;
+
+    // ----------------------------------
+    // IF FLAGS
+    // ----------------------------------
+    int PI_DISABLE_FIFO_IF = 1;
+    int PI_DISABLE_SOCK_IF = 2;
+    int PI_LOCALHOST_SOCK_IF = 4;
+    int PI_DISABLE_ALERT = 8;
 }

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpioConst.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpioConst.java
@@ -418,8 +418,8 @@ public interface PiGpioConst {
     // ----------------------------------
     // IF FLAGS
     // ----------------------------------
-    int PI_DISABLE_FIFO_IF = 1;
-    int PI_DISABLE_SOCK_IF = 2;
-    int PI_LOCALHOST_SOCK_IF = 4;
+    int PI_IF_DISABLE_FIFO = 1; // PI_DISABLE_FIFO_IF in pigpio.h
+    int PI_IF_DISABLE_SOCK = 2; // PI_DISABLE_SOCK_IF in pigpio.h
+    int PI_IF_LOCALHOST_SOCK = 4; // PI_LOCALHOST_SOCK_IF in pigpio.h
     int PI_DISABLE_ALERT = 8;
 }

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/impl/PiGpioNativeImpl.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/impl/PiGpioNativeImpl.java
@@ -36,8 +36,8 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.Objects;
 
-import static com.pi4j.library.pigpio.PiGpioConst.PI_DISABLE_FIFO_IF;
-import static com.pi4j.library.pigpio.PiGpioConst.PI_DISABLE_SOCK_IF;
+import static com.pi4j.library.pigpio.PiGpioConst.PI_IF_DISABLE_FIFO;
+import static com.pi4j.library.pigpio.PiGpioConst.PI_IF_DISABLE_SOCK;
 import static com.pi4j.library.pigpio.PiGpioConst.PI_TIME_RELATIVE;
 
 /**
@@ -90,7 +90,7 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
 
         if(!this.initialized) {
             // disable socket and pipes interfaces
-            int rslt = PIGPIO.gpioCfgInterfaces(PI_DISABLE_FIFO_IF | PI_DISABLE_SOCK_IF);
+            int rslt = PIGPIO.gpioCfgInterfaces(PI_IF_DISABLE_FIFO | PI_IF_DISABLE_SOCK);
             validateResult(rslt);
 
             // initialize the PiGpio native library

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/impl/PiGpioNativeImpl.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/impl/PiGpioNativeImpl.java
@@ -91,6 +91,7 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
         if(!this.initialized) {
             // disable socket and pipes interfaces
             int rslt = PIGPIO.gpioCfgInterfaces(PI_DISABLE_FIFO_IF | PI_DISABLE_SOCK_IF);
+            validateResult(rslt);
 
             // initialize the PiGpio native library
             result = PIGPIO.gpioInitialise();

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/impl/PiGpioNativeImpl.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/impl/PiGpioNativeImpl.java
@@ -36,6 +36,8 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.Objects;
 
+import static com.pi4j.library.pigpio.PiGpioConst.PI_DISABLE_FIFO_IF;
+import static com.pi4j.library.pigpio.PiGpioConst.PI_DISABLE_SOCK_IF;
 import static com.pi4j.library.pigpio.PiGpioConst.PI_TIME_RELATIVE;
 
 /**
@@ -88,7 +90,7 @@ public class PiGpioNativeImpl extends PiGpioBase implements PiGpio {
 
         if(!this.initialized) {
             // disable socket and pipes interfaces
-            int rslt = PIGPIO.gpioCfgInterfaces(3);
+            int rslt = PIGPIO.gpioCfgInterfaces(PI_DISABLE_FIFO_IF | PI_DISABLE_SOCK_IF);
 
             // initialize the PiGpio native library
             result = PIGPIO.gpioInitialise();


### PR DESCRIPTION
While trying to read and understand `PiGpioNativeImpl#gpioInitialise` I struggled quite a bit to understand what the parameter value `3` of the `gpioCfgInterfaces` call actually means. So in my [first commit](4e24214a71448e6e61d808b400e895a497509b5c) I’m suggesting to dissolve the magic value `3` by using new constants that I’m adding to `PiGpioConst`. I’ve taken the constants from https://github.com/joan2937/pigpio/blob/master/pigpio.h.

In my [second commit](e953d99aad1ef403a9ba2af67fa8d8b1c39dcaf9) I’m suggesting to also validate the return value of the call to `gpioCfgInterfaces`. Currently Pi4J wouldn’t notice when pigpio returns an error in the `gpioCfgInterfaces` call.

Let me know what you think about my suggested improvements.

In a potential follow-up improvement, users could also be allowed to add the `PI_DISABLE_ALERT` flag¹. This was actually the triggering reason for my research since I saw about 5-7% CPU load on idle on my Raspberry Pi 3. Apparently it’s a known behavior of pigpio which is discussed in https://github.com/joan2937/pigpio/issues/29. Users who don’t need to wait for input events might want to add the `PI_DISABLE_ALERT` flag to shave off some unnecessary CPU load.

¹ _It is the same as adding the `-m` parameter to [`pigpiod`](https://abyz.me.uk/rpi/pigpio/pigpiod.html)_