### PR TITLE
Extended Providers with a priority and have mock plugins marked as such

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/Pi4J.java
+++ b/pi4j-core/src/main/java/com/pi4j/Pi4J.java
@@ -59,16 +59,33 @@ public class Pi4J {
     }
 
     /**
-     * Returns a new 'Context' instance which represents the Pi4J runtime
+     * <p>Returns a new 'Context' instance which represents the Pi4J runtime
      * state and lifecycle.   This 'Context' instance will automatically
      * load all detected 'Platforms' and 'Providers' that are detected
-     * in the application's class-path.
+     * in the application's class-path.</p>
+     *
+     * <p>This method does not allow mock plugins to be used. If this is required, e.g. for testing then use {@link #newAutoContextAllowMocks()}</p>
      *
      * @return Context
      */
     public static Context newAutoContext() {
         logger.info("New auto context");
         return newContextBuilder().autoDetect().build();
+    }
+
+    /**
+     * <p>Returns a new 'Context' instance which represents the Pi4J runtime
+     * state and lifecycle.   This 'Context' instance will automatically
+     * load all detected 'Platforms' and 'Providers' that are detected
+     * in the application's class-path.</p>
+     *
+     * <p>In contrast to {@link #newAutoContext()} this method will allow mocks to be added to the runtime.</p>
+     *
+     * @return Context
+     */
+    public static Context newAutoContextAllowMocks() {
+        logger.info("New auto context");
+        return newContextBuilder().autoDetect().autoDetectMockPlugins().build();
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/context/ContextBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/ContextBuilder.java
@@ -86,6 +86,13 @@ public interface ContextBuilder extends Builder<Context> {
     ContextBuilder defaultPlatform(String platformId);
 
     /**
+     * <p>autoDetectMockPlugins.</p>
+     *
+     * @return a {@link com.pi4j.context.ContextBuilder} object.
+     */
+    ContextBuilder autoDetectMockPlugins();
+
+    /**
      * <p>autoDetectPlatforms.</p>
      *
      * @return a {@link com.pi4j.context.ContextBuilder} object.

--- a/pi4j-core/src/main/java/com/pi4j/context/ContextConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/ContextConfig.java
@@ -57,6 +57,12 @@ public interface ContextConfig {
         return platforms();
     }
     /**
+     * <p>autoDetectMockPlugins.</p>
+     *
+     * @return a boolean.
+     */
+    boolean autoDetectMockPlugins();
+    /**
      * <p>autoDetectPlatforms.</p>
      *
      * @return a boolean.

--- a/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContextBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContextBuilder.java
@@ -50,6 +50,7 @@ public class DefaultContextBuilder implements ContextBuilder {
     protected Logger logger = LoggerFactory.getLogger(DefaultContextBuilder.class);
 
     // auto detection flags
+    protected boolean autoDetectMockPlugins = false;
     protected boolean autoDetectPlatforms = false;
     protected boolean autoDetectProviders = false;
     protected boolean autoInject = false;
@@ -106,6 +107,11 @@ public class DefaultContextBuilder implements ContextBuilder {
     @Override
     public ContextBuilder defaultPlatform(String platformId) {
         this.defaultPlatformId = platformId;
+        return this;
+    }
+
+    public ContextBuilder autoDetectMockPlugins() {
+        this.autoDetectMockPlugins = true;
         return this;
     }
 
@@ -248,6 +254,10 @@ public class DefaultContextBuilder implements ContextBuilder {
                 return builder.defaultPlatformId;
             }
 
+            @Override
+            public boolean autoDetectMockPlugins() {
+                return builder.autoDetectMockPlugins;
+            }
             @Override
             public boolean autoDetectPlatforms() {
                 return builder.autoDetectPlatforms;

--- a/pi4j-core/src/main/java/com/pi4j/extension/Plugin.java
+++ b/pi4j-core/src/main/java/com/pi4j/extension/Plugin.java
@@ -53,4 +53,13 @@ public interface Plugin  {
     default void shutdown(Context context) throws ShutdownException {
         // do nothing <optional override>
     }
+
+    /**
+     * <p>Returns true if this plugin is a mock plugin, and shouldn't generally be used</p>
+     *
+     * @return a boolean
+     */
+    default boolean isMock() {
+        return false;
+    }
 }

--- a/pi4j-core/src/main/java/com/pi4j/provider/Provider.java
+++ b/pi4j-core/src/main/java/com/pi4j/provider/Provider.java
@@ -67,6 +67,16 @@ public interface Provider<PROVIDER_TYPE extends Provider, IO_TYPE extends IO, CO
      * @return a {@link com.pi4j.io.IOType} object.
      */
     default IOType getType() { return type(); }
+
+    /**
+     * Returns the priority for this provider, defaults to 0
+     *
+     * @return an integer
+     */
+    default int getPriority() {
+        return 0;
+    }
+
     /**
      * <p>isType.</p>
      *

--- a/pi4j-core/src/main/java/com/pi4j/runtime/impl/DefaultRuntime.java
+++ b/pi4j-core/src/main/java/com/pi4j/runtime/impl/DefaultRuntime.java
@@ -341,7 +341,7 @@ public class DefaultRuntime implements Runtime {
     }
 
     private void notifyInitListeners() {
-        // TODO
+        initializedEventManager.dispatch(new InitializedEvent(this.context));
     }
 
     @Override

--- a/pi4j-core/src/main/java/com/pi4j/runtime/impl/DefaultRuntime.java
+++ b/pi4j-core/src/main/java/com/pi4j/runtime/impl/DefaultRuntime.java
@@ -217,10 +217,8 @@ public class DefaultRuntime implements Runtime {
             plugins.clear();
 
             // container sets for providers and platforms to load
-            // copy all configured platforms and providers defined in the context configuration
-            Set<Platform> platforms = new HashSet<>(context().config().getPlatforms());
+            Set<Platform> platforms = new HashSet<>();
             Map<IOType, Provider> providers = new HashMap<>();
-            context().config().getProviders().forEach(provider -> addProvider(provider, providers));
 
 			// only attempt to load platforms and providers from the classpath if an auto detect option is enabled
             ContextConfig config = context.config();
@@ -265,6 +263,16 @@ public class DefaultRuntime implements Runtime {
                     }
 				}
             }
+
+            // now add the explicit platforms and providers
+            platforms.addAll(context().config().getPlatforms());
+            context().config().getProviders().forEach(provider -> {
+                Provider replaced = providers.put(provider.getType(), provider);
+                if (replaced != null) {
+                    logger.warn("Replacing auto detected provider {} {} with provider {} from context config",
+                        provider.getType(), provider.getName(), replaced.getName());
+                }
+            });
 
             // initialize I/O registry
             this.registry.initialize();

--- a/pi4j-test/src/test/java/com/pi4j/test/context/ContextTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/context/ContextTest.java
@@ -51,7 +51,7 @@ public class ContextTest {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newAutoContextAllowMocks();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRawDataTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRawDataTest.java
@@ -67,7 +67,7 @@ public class I2CRawDataTest {
         // An auto context enabled AUTO-DETECT loading
         // which will load any detected Pi4J extension
         // libraries (Platforms and Providers) from the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newAutoContextAllowMocks();
     }
 
     @AfterEach

--- a/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRegisterDataTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/i2c/I2CRegisterDataTest.java
@@ -68,7 +68,7 @@ public class I2CRegisterDataTest {
         // An auto context enabled AUTO-DETECT loading
         // which will load any detected Pi4J extension
         // libraries (Platforms and Providers) from the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newAutoContextAllowMocks();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/io/spi/SpiRawDataTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/io/spi/SpiRawDataTest.java
@@ -66,7 +66,7 @@ public class SpiRawDataTest {
         // An auto context enabled AUTO-DETECT loading
         // which will load any detected Pi4J extension
         // libraries (Platforms and Providers) from the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newAutoContextAllowMocks();
     }
 
     @AfterEach

--- a/pi4j-test/src/test/java/com/pi4j/test/platform/AutoPlatformsTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/platform/AutoPlatformsTest.java
@@ -48,7 +48,7 @@ public class AutoPlatformsTest {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newAutoContextAllowMocks();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/provider/AutoProvidersTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/provider/AutoProvidersTest.java
@@ -51,7 +51,7 @@ public class AutoProvidersTest {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newAutoContextAllowMocks();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/provider/ManualProvidersCtorTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/provider/ManualProvidersCtorTest.java
@@ -52,21 +52,19 @@ public class ManualProvidersCtorTest {
         PwmProvider pwmProvider = TestPwmProvider.newInstance();
         I2CProvider i2CProvider = TestI2CProvider.newInstance();
         SerialProvider serialProvider = TestSerialProvider.newInstance();
-        SerialProvider serialProvider2 = TestSerialProvider.newInstance("test-serial-provider-2");
 
         // Initialize Pi4J with a manually configured context
         // ...
         // Explicitly add the test providers into the
         // context for testing
-        pi4j = Pi4J.newContextBuilder()
-                .add(pwmProvider, i2CProvider, serialProvider, serialProvider2)
-                .build();
+        pi4j = Pi4J.newContextBuilder().add(pwmProvider, i2CProvider, serialProvider).build();
     }
 
     @AfterAll
     public void afterTest() {
         try {
-            pi4j.shutdown();
+            if (this.pi4j != null)
+                pi4j.shutdown();
         } catch (Pi4JException e) { /* do nothing */ }
     }
 
@@ -78,8 +76,8 @@ public class ManualProvidersCtorTest {
 
     @Test
     public void testProviderCount() {
-        // ensure that only 4 providers were detected/loaded into the Pi4J context
-        assertEquals(4 , pi4j.providers().all().size());
+        // ensure that only 3 providers were detected/loaded into the Pi4J context
+        assertEquals(3 , pi4j.providers().all().size());
 
         // print out the detected Pi4J platforms
         pi4j.platforms().describe().print(System.out);

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryGetIoInstance.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryGetIoInstance.java
@@ -53,7 +53,7 @@ public class RegistryGetIoInstance {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newAutoContextAllowMocks();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
@@ -52,7 +52,7 @@ public class RegistryTest {
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        pi4j = Pi4J.newAutoContext();
+        pi4j = Pi4J.newAutoContextAllowMocks();
     }
 
     @AfterAll

--- a/pi4j-test/src/test/java/com/pi4j/test/runtime/RuntimeTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/runtime/RuntimeTest.java
@@ -48,12 +48,11 @@ public class RuntimeTest {
     @Test
     public void testRuntimeShutdownEvents() throws Pi4JException {
 
-
         // initialize Pi4J with an auto context
         // An auto context includes AUTO-DETECT BINDINGS enabled
         // which will load all detected Pi4J extension libraries
         // (Platforms and Providers) in the class path
-        Context pi4j = Pi4J.newAutoContext();
+        Context pi4j = Pi4J.newAutoContextAllowMocks();
 
         logger.info("-------------------------------------------------");
         logger.info("Pi4J CONTEXT <acquired via factory accessor>");

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalInputProviderImpl.java
@@ -51,6 +51,12 @@ public class LinuxFsDigitalInputProviderImpl extends DigitalInputProviderBase im
         this.gpioFileSystemPath = gpioFileSystemPath;
     }
 
+    @Override
+    public int getPriority() {
+        // the linux FS DI driver should not be used over the pigpio
+        return 50;
+    }
+
     /** {@inheritDoc} */
     @Override
     public DigitalInput create(DigitalInputConfig config) {

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/gpio/digital/LinuxFsDigitalOutputProviderImpl.java
@@ -51,6 +51,12 @@ public class LinuxFsDigitalOutputProviderImpl extends DigitalOutputProviderBase 
         this.gpioFileSystemPath = gpioFileSystemPath;
     }
 
+    @Override
+    public int getPriority() {
+        // the linux FS DO driver should not be used over the pigpio
+        return 50;
+    }
+
     /** {@inheritDoc} */
     @Override
     public DigitalOutput create(DigitalOutputConfig config) {

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2CProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/i2c/LinuxFsI2CProviderImpl.java
@@ -45,6 +45,12 @@ public class LinuxFsI2CProviderImpl extends I2CProviderBase implements LinuxFsI2
     }
 
     @Override
+    public int getPriority() {
+        // the linux FS I2C driver should be used over the pigpio
+        return 150;
+    }
+
+    @Override
     public I2C create(I2CConfig config) {
         synchronized (this) {
             LinuxFsI2CBus i2CBus = this.i2CBusMap.computeIfAbsent(config.getBus(), busNr -> new LinuxFsI2CBus(config));

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/pwm/LinuxFsPwmProviderImpl.java
@@ -55,6 +55,12 @@ public class LinuxFsPwmProviderImpl extends PwmProviderBase implements LinuxFsPw
         this.pwmChip = pwmChip;
     }
 
+    @Override
+    public int getPriority() {
+        // the linux FS PWM driver should not be used over the pigpio
+        return 50;
+    }
+
     /**
      * <p>Constructor for LinuxFsPwmProviderImpl.</p>
      */

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/MockPlugin.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/MockPlugin.java
@@ -48,7 +48,7 @@ import com.pi4j.provider.Provider;
  */
 public class MockPlugin implements Plugin {
 
-    private Provider providers[] = {
+    private final Provider[] providers = {
             MockAnalogInputProvider.newInstance(),
             MockAnalogOutputProvider.newInstance(),
             MockDigitalInputProvider.newInstance(),
@@ -59,13 +59,16 @@ public class MockPlugin implements Plugin {
             MockSerialProvider.newInstance(),
     };
 
+    @Override
+    public boolean isMock() {
+        return true;
+    }
+
     /** {@inheritDoc} */
     @Override
     public void initialize(PluginService service) {
 
         // register the Mock Platform and all Mock I/O Providers with the plugin service
-        service.register(new MockPlatform())
-               .register(providers);
-
+        service.register(new MockPlatform()).register(providers);
     }
 }

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/analog/MockAnalogInputProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/analog/MockAnalogInputProviderImpl.java
@@ -47,6 +47,12 @@ public class MockAnalogInputProviderImpl extends AnalogInputProviderBase impleme
         this.name = NAME;
     }
 
+    @Override
+    public int getPriority() {
+        // if the mock is loaded, then we most probably want to use it for testing
+        return 1000;
+    }
+
     /** {@inheritDoc} */
     @Override
     public AnalogInput create(AnalogInputConfig config) {

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/analog/MockAnalogOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/analog/MockAnalogOutputProviderImpl.java
@@ -48,10 +48,15 @@ public class MockAnalogOutputProviderImpl extends AnalogOutputProviderBase imple
         this.name = NAME;
     }
 
+    @Override
+    public int getPriority() {
+        // if the mock is loaded, then we most probably want to use it for testing
+        return 1000;
+    }
+
     /** {@inheritDoc} */
     @Override
     public AnalogOutput create(AnalogOutputConfig config) {
         return new MockAnalogOutput(this, config);
     }
-
 }

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalInputProviderImpl.java
@@ -47,6 +47,12 @@ public class MockDigitalInputProviderImpl extends DigitalInputProviderBase imple
         this.name = NAME;
     }
 
+    @Override
+    public int getPriority() {
+        // if the mock is loaded, then we most probably want to use it for testing
+        return 1000;
+    }
+
     /** {@inheritDoc} */
     @Override
     public DigitalInput create(DigitalInputConfig config) {

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/gpio/digital/MockDigitalOutputProviderImpl.java
@@ -47,6 +47,12 @@ public class MockDigitalOutputProviderImpl extends DigitalOutputProviderBase imp
         this.name = NAME;
     }
 
+    @Override
+    public int getPriority() {
+        // if the mock is loaded, then we most probably want to use it for testing
+        return 1000;
+    }
+
     /** {@inheritDoc} */
     @Override
     public DigitalOutput create(DigitalOutputConfig config) {

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/i2c/MockI2CProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/i2c/MockI2CProviderImpl.java
@@ -47,6 +47,12 @@ public class MockI2CProviderImpl extends I2CProviderBase implements MockI2CProvi
         this.name = NAME;
     }
 
+    @Override
+    public int getPriority() {
+        // if the mock is loaded, then we most probably want to use it for testing
+        return 1000;
+    }
+
     /** {@inheritDoc} */
     @Override
     public I2C create(I2CConfig config) {

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/pwm/MockPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/pwm/MockPwmProviderImpl.java
@@ -47,6 +47,12 @@ public class MockPwmProviderImpl extends PwmProviderBase implements MockPwmProvi
         this.name = NAME;
     }
 
+    @Override
+    public int getPriority() {
+        // if the mock is loaded, then we most probably want to use it for testing
+        return 1000;
+    }
+
     /** {@inheritDoc} */
     @Override
     public Pwm create(PwmConfig config) {

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/serial/MockSerialProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/serial/MockSerialProviderImpl.java
@@ -48,6 +48,12 @@ public class MockSerialProviderImpl extends SerialProviderBase implements MockSe
         this.name = NAME;
     }
 
+    @Override
+    public int getPriority() {
+        // if the mock is loaded, then we most probably want to use it for testing
+        return 1000;
+    }
+
     /** {@inheritDoc} */
     @Override
     public Serial create(SerialConfig config) {

--- a/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/spi/MockSpiProviderImpl.java
+++ b/plugins/pi4j-plugin-mock/src/main/java/com/pi4j/plugin/mock/provider/spi/MockSpiProviderImpl.java
@@ -47,6 +47,12 @@ public class MockSpiProviderImpl extends SpiProviderBase implements MockSpiProvi
         this.name = NAME;
     }
 
+    @Override
+    public int getPriority() {
+        // if the mock is loaded, then we most probably want to use it for testing
+        return 1000;
+    }
+
     /** {@inheritDoc} */
     @Override
     public Spi create(SpiConfig config) {

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalInputProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalInputProviderImpl.java
@@ -53,6 +53,12 @@ public class PiGpioDigitalInputProviderImpl extends DigitalInputProviderBase imp
         this.piGpio = piGpio;
     }
 
+    @Override
+    public int getPriority() {
+        // the pigpio DI driver should be used over the default
+        return 100;
+    }
+
     /** {@inheritDoc} */
     @Override
     public DigitalInput create(DigitalInputConfig config) {

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalOutputProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/gpio/digital/PiGpioDigitalOutputProviderImpl.java
@@ -53,6 +53,12 @@ public class PiGpioDigitalOutputProviderImpl extends DigitalOutputProviderBase i
         this.piGpio = piGpio;
     }
 
+    @Override
+    public int getPriority() {
+        // the pigpio DO driver should be used over the default
+        return 100;
+    }
+
     /** {@inheritDoc} */
     @Override
     public DigitalOutput create(DigitalOutputConfig config) {

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/i2c/PiGpioI2CProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/i2c/PiGpioI2CProviderImpl.java
@@ -53,6 +53,12 @@ public class PiGpioI2CProviderImpl extends I2CProviderBase implements PiGpioI2CP
         this.piGpio = piGpio;
     }
 
+    @Override
+    public int getPriority() {
+        // the pigpio I2C driver should be used over the default
+        return 100;
+    }
+
     /** {@inheritDoc} */
     @Override
     public I2C create(I2CConfig config) {

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/pwm/PiGpioPwmProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/pwm/PiGpioPwmProviderImpl.java
@@ -54,6 +54,12 @@ public class PiGpioPwmProviderImpl extends PwmProviderBase implements PiGpioPwmP
         this.piGpio = piGpio;
     }
 
+    @Override
+    public int getPriority() {
+        // the pigpio PWM driver should be used over the default
+        return 100;
+    }
+
     /** {@inheritDoc} */
     @Override
     public Pwm create(PwmConfig config) {

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/serial/PiGpioSerialProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/serial/PiGpioSerialProviderImpl.java
@@ -53,6 +53,12 @@ public class PiGpioSerialProviderImpl extends SerialProviderBase implements PiGp
         this.piGpio = piGpio;
     }
 
+    @Override
+    public int getPriority() {
+        // the pigpio Serial driver should be used over the default
+        return 100;
+    }
+
     /** {@inheritDoc} */
     @Override
     public Serial create(SerialConfig config) {

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/spi/PiGpioSpiProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/spi/PiGpioSpiProviderImpl.java
@@ -53,6 +53,12 @@ public class PiGpioSpiProviderImpl extends SpiProviderBase implements PiGpioSpiP
         this.piGpio = piGpio;
     }
 
+    @Override
+    public int getPriority() {
+        // the pigpio SPI driver should be used over the default
+        return 100;
+    }
+
     /** {@inheritDoc} */
     @Override
     public Spi create(SpiConfig config) {

--- a/providers.csv
+++ b/providers.csv
@@ -1,0 +1,23 @@
+Plugin,Provider Class,Name,Priority,Digital Output,Digital Input,PWM,I2C,SPI,Serial,Analog Input,Analog Output
+pi4j-plugin-raspberrypi,RpiDigitalOutputProvider,raspberrypi-digital-output,0,x,,,,,,,
+pi4j-plugin-raspberrypi,RpiDigitalInputProvider,raspberrypi-digital-input,0,,x
+pi4j-plugin-raspberrypi,RpiPwmProvider,raspberrypi-pwm,0,,,x
+pi4j-plugin-raspberrypi,RpiI2CProvider,raspberrypi-i2c,0,,,,x
+pi4j-plugin-raspberrypi,RpiSpiProvider,raspberrypi-spi,0,,,,,x
+pi4j-plugin-raspberrypi,RpiSerialProvider,raspberrypi-serial,0,,,,,,x
+pi4j-plugin-pigpio,PiGpioDigitalOutputProvider,pigpio-digital-output,100,x
+pi4j-plugin-pigpio,PiGpioDigitalInputProvider,pigpio-digital-input,100,,x
+pi4j-plugin-pigpio,PiGpioPwmProvider,pigpio-pwm,100,,,x
+pi4j-plugin-pigpio,PiGpioI2CProvider,pigpio-i2c,100,,,,x
+pi4j-plugin-pigpio,PiGpioSpiProvider,pigpio-spi,100,,,,,x
+pi4j-plugin-pigpio,PiGpioSerialProvider,pigpio-serial,100,,,,,,x
+pi4j-plugin-mock,MockDigitalOutputProvider,mock-digital-output,1000,x
+pi4j-plugin-mock,MockDigitalInputProvider,mock-digital-input,1000,,x
+pi4j-plugin-mock,MockPwmProvider,mock-pwm,1000,,,x
+pi4j-plugin-mock,MockI2CProvider,mock-i2c,1000,,,,x
+pi4j-plugin-mock,MockSpiProvider,mock-spi,1000,,,,,x
+pi4j-plugin-mock,MockSerialProvider,mock-serial,1000,,,,,,x
+pi4j-plugin-linuxfs,LinuxFsDigitalOutputProvider,linuxfs-digital-output,50,x
+pi4j-plugin-linuxfs,LinuxFsDigitalInputProvider,linuxfs-digital-input,50,,x
+pi4j-plugin-linuxfs,LinuxFsPwmProvider,linuxfs-pwm,50,,,x,
+pi4j-plugin-linuxfs,LinuxFsI2CProvider,linuxfs-i2c,150,,,,x


### PR DESCRIPTION
### Extended Providers with a priority
This priority helps to determine which Provider should be loaded, when multiple providers with the same IOType are being loaded by different plugins.

This change enforces that a given IOType can only have one Provider loaded at runtime. Currently there is no known situation where this would be necessary, but could lead to problems if for instance two I2C providers are loaded at the same time, concurrently writing to the I2C bus.

Providers explicitly passed in the context config override the priority.

### Better handling of mock plugins
Plugins can now define if they are mocks, and these are not auto-detected anymore.

The default target for the pi4j library is the Raspberry Pi, and thus auto-detecting mocks on the Pi, which are only for tests is counterintuitive.