### PR TITLE
the change from using ls -l provided less info to the utility. Previo…

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/boardinfo/util/PwmChipUtil.java
+++ b/pi4j-core/src/main/java/com/pi4j/boardinfo/util/PwmChipUtil.java
@@ -139,6 +139,8 @@ public class PwmChipUtil {
                     chipName.append(path.charAt(numStart));
                     chipNum = new StringBuilder().append(chipNum.substring(0, chipNum.length())).append(path.substring(numStart, numStart + 1)).toString();
                     numStart++;
+                    if (numStart == path.length())
+                        break ;
                 }
                 return Optional.of(Integer.parseInt(chipNum));
             }

--- a/pi4j-core/src/test/java/com/pi4j/boardinfo/util/PWMChipUtilTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/boardinfo/util/PWMChipUtilTest.java
@@ -13,8 +13,8 @@ class PWMChipUtilTest {
     @Test
     void shouldReturnCorrectPWMChipForRP1Paths() {
         var paths = List.of("total 0  ",
-            "lrwxrwxrwx 1root root 0Aug 20 07:51 pwmchip42 ->../../devices / platform / axi / 1000120000. pcie / 1f00098000. pwm / pwm / pwmchip0",
-            "lrwxrwxrwx 1 root root 0 Aug 20 07:51 pwmchip1 ->../../devices / platform / axi / 1000120000. pcie / 1f 0009c000.pwm / pwm / pwmchip1"
+            "../../devices/platform/axi/1000120000.pcie/1f00098000.pwm/pwm/pwmchip42",
+            "../../devices/platform/axi/1000120000.pcie/1f0009c000.pwm/pwm/pwmchip1"
         );
 
         Optional<Optional<Integer>> optionalInt = Optional.of(parsePWMPaths(paths));


### PR DESCRIPTION
…ulsy the pwmchip number was found early in the path detail and at the end. Now it is only at the end of the path.  The code as it was walked off the end of the array.  The fix a simple break.