### PR TITLE
Move default chip check to FFM providers

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContextBuilder.java
+++ b/pi4j-core/src/main/java/com/pi4j/context/impl/DefaultContextBuilder.java
@@ -304,7 +304,6 @@ public class DefaultContextBuilder implements ContextBuilder {
 
             @Override
             public Map<String, String> properties() {
-                builder.properties.put("gpio.chip.name", gpioChipName != null ? gpioChipName : "unknown");
                 return Collections.unmodifiableMap(builder.properties);
             }
         };

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalInputFFMProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalInputFFMProviderImpl.java
@@ -19,7 +19,7 @@ public class DigitalInputFFMProviderImpl extends DigitalInputProviderBase implem
 
     @Override
     public DigitalInput create(DigitalInputConfig config) {
-        var chipName = context.config().properties().get("gpio.chip.name");
+        var chipName = context.config().properties().getOrDefault("gpio.chip.name", "unknown");
         var digitalInput = new DigitalInputFFM(chipName, this, config);
         this.context.registry().add(digitalInput);
         return digitalInput;

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalOutputFFMProviderImpl.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/DigitalOutputFFMProviderImpl.java
@@ -20,7 +20,7 @@ public class DigitalOutputFFMProviderImpl extends DigitalOutputProviderBase impl
 
     @Override
     public DigitalOutput create(DigitalOutputConfig config) {
-        var chipName = context.config().properties().get("gpio.chip.name");
+        var chipName = context.config().properties().getOrDefault("gpio.chip.name", "unknown");
         var digitalOutput = new DigitalOutputFFM(chipName, this, config);
         this.context.registry().add(digitalOutput);
         return digitalOutput;


### PR DESCRIPTION
This PR suggests an alternative approach for the FFM plugin to read a default value for `gpio.chip.name` so as not to break existing functionality as described in #500 

If necessary, maybe changing the "default values" behaviour in shared code can be addressed by a separate issue and PR instead