### PR TITLE
Make sure simple listeners can be removed again

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/event/EventManager.java
+++ b/pi4j-core/src/main/java/com/pi4j/event/EventManager.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Predicate;
 
 public class EventManager<SOURCE_TYPE, LISTENER_TYPE extends Listener, EVENT_TYPE> {
     private Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -55,6 +56,11 @@ public class EventManager<SOURCE_TYPE, LISTENER_TYPE extends Listener, EVENT_TYP
 
     public SOURCE_TYPE remove(LISTENER_TYPE ... listener){
         listeners.removeAll(List.of(listener));
+        return this.source;
+    }
+
+    public SOURCE_TYPE remove(Predicate<LISTENER_TYPE> condition){
+        listeners.removeIf(condition);
         return this.source;
     }
 

--- a/pi4j-core/src/main/java/com/pi4j/io/ListenableOnOffRead.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/ListenableOnOffRead.java
@@ -44,7 +44,9 @@ public interface ListenableOnOffRead<T> extends OnOffRead<T> {
      * Adds a boolean consumer as a listener to this object. This method name was chosen to avoid any ambiguity with
      * addListener in Digital.
      */
-    T addConsumer(Consumer<Boolean> listener);
+    Consumer<Boolean> addConsumer(Consumer<Boolean> listener);
+
+    T removeConsumer(Consumer<Boolean> listener);
 
     /**
      * A simple implementation that will notify listeners for state-changing on()/off() (or setState()) calls.
@@ -88,8 +90,14 @@ public interface ListenableOnOffRead<T> extends OnOffRead<T> {
         }
 
         @Override
-        public Impl addConsumer(Consumer<Boolean> listener) {
+        public Consumer<Boolean> addConsumer(Consumer<Boolean> listener) {
             listeners.add(listener);
+            return listener;
+        }
+
+        @Override
+        public Impl removeConsumer(Consumer<Boolean> listener) {
+            listeners.remove(listener);
             return this;
         }
     }


### PR DESCRIPTION
Returning the listener from addConsumer will enable the following compact pattern

```
void setup() {
   upListener = upKey.addConsumer(value -> processDirection(value, 0, -1)),
   downListener = downKey.addConsumer(value -> processDirection(value, 0, 1)),
   leftListener = leftKey.addConsumer(value -> processDirection(value, -1, 0)),
   rightListener = rightKey.addConsumer(value -> processDirection(value, 1, 0)));
}

void shutdown() {
  upKey.removeConsumer(upListener);
  downKey.removeConsumer(downListener);
  leftKey.removeConsumer(leftListener);
  rightListener.removeConsumer(rightListener);
}
```

The code snippet is from a snake game for the two hats we are supporting in drivers which I'd like to add to examples.