### PR TITLE
Spi writeRead   write and read operation contained in single ioctl

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/spi/Spi.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/Spi.java
@@ -368,21 +368,19 @@ public interface Spi extends IO<Spi, SpiConfig, SpiProvider>, AutoCloseable, IOD
     }
 
     // ------------------------------------------------------------------------------------
-    //  writeRead
+    //  writeThenRead
     // ------------------------------------------------------------------------------------
     /**
      * This function writes bytes to the SPI device and then reads bytes from the device
      * Write data is taken from the 'buffer' byte array, data
      * read back from the SPI device is then copied to the 'read' byte array
      *
-     * @param buffer the array of bytes to write to the SPI device
+     * @param write the array of bytes to write to the SPI device
 
      * @param read   Buffer to contain read data
-     * @return Returns 0 if OK, otherwise PI_BAD_HANDLE, PI_BAD_SPI_COUNT, or PI_SPI_XFER_FAILED.
-     * @see "http://abyz.me.uk/rpi/pigpio/cif.html#spiWrite"
      */
-    default int writeRead(byte[] buffer,  byte[] read) {
-        return writeRead(buffer, 0, buffer.length, (short) 0, read, 0, read.length, (short) 0);
+    default void  writeThenRead(byte[] write,  byte[] read) {
+         writeThenRead(write, 0, write.length, (short) 0, read, 0, read.length, (short) 0);
     }
 
     /**
@@ -390,16 +388,14 @@ public interface Spi extends IO<Spi, SpiConfig, SpiProvider>, AutoCloseable, IOD
      * Write data is taken from the 'buffer' byte array, data
      * read back from the SPI device is then copied to the 'read' byte array
      *
-     * @param buffer the array of bytes to write to the SPI device
+     * @param write the array of bytes to write to the SPI device
      * @param writeLength
      *               Number bytes written from buffer to the SPI
      * @param read   Buffer to contain read data
      * @param readlength the number of bytes to read (read &amp; read))
-     * @return Returns 0 if OK, otherwise PI_BAD_HANDLE, PI_BAD_SPI_COUNT, or PI_SPI_XFER_FAILED.
-     * @see "http://abyz.me.uk/rpi/pigpio/cif.html#spiWrite"
      */
-    default int writeRead(byte[] buffer, int writeLength,  byte[] read,  int readlength) {
-        return writeRead(buffer, 0, writeLength, (short) 0, read, 0, readlength, (short) 0);
+    default void writeThenRead(byte[] write, int writeLength,  byte[] read,  int readlength) {
+        writeThenRead(write, 0, writeLength, (short) 0, read, 0, readlength, (short) 0);
     }
 
 
@@ -421,19 +417,17 @@ public interface Spi extends IO<Spi, SpiConfig, SpiProvider>, AutoCloseable, IOD
      *                           start writing to the SPI device from and the position
      *                           used as the starting offset position to place data bytes
      *                           read back from the SPI device.
-     * @param writeNumberOfBytes Number of bytes written from write buffer
+     * @param writeLength        Number of bytes written from write buffer
      * @param writeDelayUsecs    Delay after SPI write record processed by kernel before the
      *                           read SPI record is processed. Value in usecs.
      * @param read               Buffer to contain read data
      * @param readOffset         Offset within the read buffer to begin placing read data
-     * @param readNumberOfBytes  the number of bytes to transfer/exchange (read &amp; read))
-     * @param readDelayUsecs    Delay after SPI read record processed by kernel before the
+     * @param readLength         The number of bytes to transfer/exchange (read &amp; read))
+     * @param readDelayUsecs     Delay after SPI read record processed by kernel before the
      *                           read SPI record is processed. Value in usecs.
-     * @return Returns 0 if OK, otherwise PI_BAD_HANDLE, PI_BAD_SPI_COUNT, or PI_SPI_XFER_FAILED.
-     * @see "http://abyz.me.uk/rpi/pigpio/cif.html#spiWrite"
      */
-    default int writeRead(byte[] write, int writeOffset, int writeNumberOfBytes,  short writeDelayUsecs, byte[] read, int readOffset, int readNumberOfBytes,  short readDelayUsecs) {
-        throw new IllegalStateException("writeRead Not supported in this provider. \n See https://www.pi4j.com/documentation/providers/");
+    default void writeThenRead(byte[] write, int writeOffset, int writeLength,  short writeDelayUsecs, byte[] read, int readOffset, int readLength,  short readDelayUsecs) {
+        throw new IllegalStateException("writeThenRead Not supported in this provider. \n See https://www.pi4j.com/documentation/providers/");
     }
 
 

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/Spi.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/Spi.java
@@ -117,8 +117,7 @@ public interface Spi extends IO<Spi, SpiConfig, SpiProvider>, AutoCloseable, IOD
      *
      * @param write the array of bytes to write to the SPI device
      * @param writeOffset the starting offset position in the provided 'write' buffer to
-     *                    start writing to the SPI device from.
-     * @param read the array of bytes to store read data in from the SPI device
+     *                    start writing to the SPI device from.     * @param read the array of bytes to store read data in from the SPI device
      * @param readOffset the starting offset position in the provided 'read' buffer to place
      *                   data bytes read from the SPI device.
      * @param numberOfBytes the number of bytes to transfer/exchange (read &amp; read))
@@ -366,4 +365,59 @@ public interface Spi extends IO<Spi, SpiConfig, SpiProvider>, AutoCloseable, IOD
         // return actual number of bytes read
         return length;
     }
+
+    // ------------------------------------------------------------------------------------
+    //  Register Read
+    // ------------------------------------------------------------------------------------
+    /**
+     * This function writes multiple bytes to the SPI device and then reads bytes from the device
+     * Write data is taken from the 'buffer' byte array, data
+     * read back from the SPI device is then copied to the 'read' byte array
+     *
+     * @param buffer the array of bytes to write to the SPI device
+     * @param writeLength
+     *               Number bytes written from buffer to the SPI
+     * @param read   Buffer to contain read data
+     * @param readlength the number of bytes to read (read &amp; read))
+     * @return Returns 0 if OK, otherwise PI_BAD_HANDLE, PI_BAD_SPI_COUNT, or PI_SPI_XFER_FAILED.
+     * @see "http://abyz.me.uk/rpi/pigpio/cif.html#spiWrite"
+     */
+    default int registerRead(byte[] buffer, int writeLength,  byte[] read,  int readlength) {
+        return registerRead(buffer, 0, writeLength, (short) 0, read, 0, readlength, (short) 0);
+    }
+
+
+    /**
+     * This function writes multiple bytes to the SPI device and then reads bytes from the device
+     *  Write data is taken from the 'buffer' byte array
+     * from the given 'writeOffset' index to the specified 'writeLength' (number of bytes).  Data
+     * read back from the SPI device is then copied to the 'read' byte array starting
+     * at the given 'readOffset' using the 'readLength' (number of bytes).  The 'buffer' and  'read' byte
+     * array must be at least the size of the defined 'length' + 'offset'.
+     *
+     * In addition. both the write and read operation can provide a configurable delay
+     * allowing the effected SPI chip complete any processing.
+     *
+     * @param write              the array of bytes to write to the SPI device and to store read data
+     *                           back from the SPI device
+     * @param writeOffset        the starting offset position in the provided buffer to
+     *                           start writing to the SPI device from and the position
+     *                           used as the starting offset position to place data bytes
+     *                           read back from the SPI device.
+     * @param writeNumberOfBytes Number of bytes written from write buffer
+     * @param writeDelayUsecs    Delay after SPI write record processed by kernel before the
+     *                           read SPI record is processed. Value in usecs.
+     * @param read               Buffer to contain read data
+     * @param readOffset         Offset within the read buffer to begin placing read data
+     * @param readNumberOfBytes  the number of bytes to transfer/exchange (read &amp; read))
+     * @param readDelayUsecs    Delay after SPI read record processed by kernel before the
+     *                           read SPI record is processed. Value in usecs.
+     * @return Returns 0 if OK, otherwise PI_BAD_HANDLE, PI_BAD_SPI_COUNT, or PI_SPI_XFER_FAILED.
+     * @see "http://abyz.me.uk/rpi/pigpio/cif.html#spiWrite"
+     */
+    default int registerRead(byte[] write, int writeOffset, int writeNumberOfBytes,  short writeDelayUsecs, byte[] read, int readOffset, int readNumberOfBytes,  short readDelayUsecs) {
+        throw new IllegalStateException("Not supported in this provider. \n See https://www.pi4j.com/documentation/providers/");
+    }
+
+
 }

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/spi/LinuxFsSpi.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/spi/LinuxFsSpi.java
@@ -53,8 +53,7 @@ import static com.pi4j.plugin.linuxfs.internal.LinuxLibC.*;
  * it works to drive an SSD1306 OLED display.
  *
  * @author mpilone
- * @see
- * <a href="https://github.com/sckulkarni246/ke-rpi-samples/blob/main/spi-c-ioctl/oled_functions.c#L157">spi-c-ioctl</a>
+ * @see <a href="https://github.com/sckulkarni246/ke-rpi-samples/blob/main/spi-c-ioctl/oled_functions.c#L157">spi-c-ioctl</a>
  * @see <a href="https://github.com/torvalds/linux/blob/master/include/uapi/linux/spi/spidev.h">spidev.h</a>
  * @see <a href="https://github.com/torvalds/linux/blob/master/include/uapi/linux/spi/spi.h">spi.h</a>
  * @see <a href="https://github.com/torvalds/linux/blob/master/tools/spi/spidev_fdx.c">spidev_fdx.c</a>
@@ -65,88 +64,70 @@ public class LinuxFsSpi extends SpiBase implements Spi {
 
     private static final Logger logger = LoggerFactory.getLogger(LinuxFsSpi.class);
 
-    ///////////////////////////////////
+    /// ////////////////////////////////
     // From spidev.h
     private final static byte SPI_IOC_MAGIC = 'k';
     private final static byte SIZE_OF_BYTE = 1;
     private final static byte SIZE_OF_INT = 4;
+    /* Read / Write of SPI mode (SPI_MODE_0..SPI_MODE_3) (limited to 8 bits) */
+    private final static int SPI_IOC_RD_MODE = _IOC(_IOC_READ, SPI_IOC_MAGIC, (byte) 1, SIZE_OF_BYTE);
+    private final static int SPI_IOC_WR_MODE = _IOC(_IOC_WRITE, SPI_IOC_MAGIC, (byte) 1, SIZE_OF_BYTE);
+
+    // These could be replaced with the specific values generated from the _IOC method (a macro in the native C),
+    // but I think it is useful to see where the values come from.
+    /* Read / Write SPI bit justification */
+    private final static int SPI_IOC_RD_LSB_FIRST = _IOC(_IOC_READ, SPI_IOC_MAGIC, (byte) 2, SIZE_OF_BYTE);
+    private final static int SPI_IOC_WR_LSB_FIRST = _IOC(_IOC_WRITE, SPI_IOC_MAGIC, (byte) 2, SIZE_OF_BYTE);
+    /* Read / Write SPI device word length (1..N) */
+    private final static int SPI_IOC_RD_BITS_PER_WORD = _IOC(_IOC_READ, SPI_IOC_MAGIC, (byte) 3, SIZE_OF_BYTE);
+    private final static int SPI_IOC_WR_BITS_PER_WORD = _IOC(_IOC_WRITE, SPI_IOC_MAGIC, (byte) 3, SIZE_OF_BYTE);
+    /* Read / Write SPI device default max speed hz */
+    private final static int SPI_IOC_RD_MAX_SPEED_HZ = _IOC(_IOC_READ, SPI_IOC_MAGIC, (byte) 4, SIZE_OF_INT);
+    private final static int SPI_IOC_WR_MAX_SPEED_HZ = _IOC(_IOC_WRITE, SPI_IOC_MAGIC, (byte) 4, SIZE_OF_INT);
+    /* Read / Write of the SPI mode field */
+    private final static int SPI_IOC_RD_MODE32 = _IOC(_IOC_READ, SPI_IOC_MAGIC, (byte) 5, SIZE_OF_INT);
+    private final static int SPI_IOC_WR_MODE32 = _IOC(_IOC_WRITE, SPI_IOC_MAGIC, (byte) 5, SIZE_OF_INT);
+    private final static String SPI_DEVICE_BASE = "/dev/spidev";
+    /// ////////////////////////////////
+    // spi.h
+    private final byte SPI_CPHA = 1;    /* clock phase */
+    private final byte SPI_CPOL = 1 << 1;    /* clock polarity */
+    private final byte SPI_MODE_0 = (0 | 0);        /* (original MicroWire) */
+    private final byte SPI_MODE_1 = (0 | SPI_CPHA);
+    private final byte SPI_MODE_2 = (SPI_CPOL | 0);
+    private final byte SPI_MODE_3 = (SPI_CPOL | SPI_CPHA);
+    private final byte BITS8 = 8;
+    private final LinuxLibC libc = LinuxLibC.INSTANCE;
     private int SPI_BUFFSIZ = 4096;
+    private int fd;
+    public LinuxFsSpi(LinuxFsSpiProviderImpl provider, SpiConfig config) {
+        super(provider, config);
+        initialize();
+    }
 
     private static int SPI_IOC_MESSAGE(int n) {
         // Even though we will pass the structure to ioctl as a pointer, the command needs to know
         // the actual size of the structure (i.e. sizeof). Therefore, we use the ByValue interface
         // when getting the struct size.
         int structSize = Native.getNativeSize(spi_ioc_transfer.ByValue.class);
-        int msgSize = ((((n)*(structSize)) < (1 << _IOC_SIZEBITS))
-            ? ((n)*(structSize)) : 0);
+        int msgSize = ((((n) * (structSize)) < (1 << _IOC_SIZEBITS))
+            ? ((n) * (structSize)) : 0);
 
-        return _IOC(_IOC_WRITE, SPI_IOC_MAGIC, (byte)0, msgSize);
+        return _IOC(_IOC_WRITE, SPI_IOC_MAGIC, (byte) 0, msgSize);
     }
 
-    // These could be replaced with the specific values generated from the _IOC method (a macro in the native C),
-    // but I think it is useful to see where the values come from.
-
-    /* Read / Write of SPI mode (SPI_MODE_0..SPI_MODE_3) (limited to 8 bits) */
-    private final static int SPI_IOC_RD_MODE = _IOC(_IOC_READ, SPI_IOC_MAGIC, (byte)1, SIZE_OF_BYTE);
-    private final static int SPI_IOC_WR_MODE = _IOC(_IOC_WRITE, SPI_IOC_MAGIC, (byte)1, SIZE_OF_BYTE);
-
-    /* Read / Write SPI bit justification */
-    private final static int SPI_IOC_RD_LSB_FIRST = _IOC(_IOC_READ, SPI_IOC_MAGIC, (byte)2, SIZE_OF_BYTE);
-    private final static int SPI_IOC_WR_LSB_FIRST = _IOC(_IOC_WRITE, SPI_IOC_MAGIC, (byte)2, SIZE_OF_BYTE);
-
-    /* Read / Write SPI device word length (1..N) */
-    private final static int SPI_IOC_RD_BITS_PER_WORD = _IOC(_IOC_READ, SPI_IOC_MAGIC, (byte)3, SIZE_OF_BYTE);
-    private final static int SPI_IOC_WR_BITS_PER_WORD = _IOC(_IOC_WRITE, SPI_IOC_MAGIC, (byte)3, SIZE_OF_BYTE);
-
-    /* Read / Write SPI device default max speed hz */
-    private final static int SPI_IOC_RD_MAX_SPEED_HZ = _IOC(_IOC_READ, SPI_IOC_MAGIC, (byte)4, SIZE_OF_INT);
-    private final static int SPI_IOC_WR_MAX_SPEED_HZ = _IOC(_IOC_WRITE, SPI_IOC_MAGIC, (byte)4, SIZE_OF_INT);
-
-    /* Read / Write of the SPI mode field */
-    private final static int SPI_IOC_RD_MODE32 = _IOC(_IOC_READ, SPI_IOC_MAGIC, (byte)5, SIZE_OF_INT);
-    private final static int SPI_IOC_WR_MODE32 = _IOC(_IOC_WRITE, SPI_IOC_MAGIC, (byte)5, SIZE_OF_INT);
-
-    @Structure.FieldOrder({"tx_buf", "rx_buf",
-        "len", "speed_hz",
-        "delay_usecs", "bits_per_word", "cs_change", "tx_nbits", "rx_nbits", "word_delay_usecs", "pad"})
-    public static class spi_ioc_transfer extends Structure {
-        public long tx_buf;
-        public long rx_buf;
-
-        public int		len;
-        public int		speed_hz;
-
-        public short	delay_usecs;
-        public byte		bits_per_word;
-        public byte		cs_change;
-        public byte		tx_nbits;
-        public byte		rx_nbits;
-        public byte		word_delay_usecs;
-        public byte		pad;
-
-        public static class ByValue extends spi_ioc_transfer implements Structure.ByValue {}
+    private static spi_ioc_transfer[] getTransferArray(int numberEntries) {
+        return (spi_ioc_transfer[]) new spi_ioc_transfer().toArray(numberEntries);
     }
 
-    ///////////////////////////////////
-    // spi.h
-    private final byte 	SPI_CPHA	=	1;	/* clock phase */
-    private final byte 	SPI_CPOL	=	1 << 1;	/* clock polarity */
-
-    private final byte 	SPI_MODE_0	=	(0|0);		/* (original MicroWire) */
-    private final byte 	SPI_MODE_1	=	(0|SPI_CPHA);
-    private final byte 	SPI_MODE_2	=	(SPI_CPOL|0);
-    private final byte 	SPI_MODE_3	=	(SPI_CPOL|SPI_CPHA);
-
-
-    private final byte  BITS8 = 8;
-
-    private final static String SPI_DEVICE_BASE = "/dev/spidev";
-    private final LinuxLibC libc = LinuxLibC.INSTANCE;
-    private int fd;
-
-    public LinuxFsSpi(LinuxFsSpiProviderImpl provider, SpiConfig config) {
-        super(provider, config);
-        initialize();
+    private static Memory[] getPeerMem(int numberEntries, int size) {
+        Memory[] memArray = new Memory[numberEntries];
+        ;
+        for (int i = 0; i < numberEntries; i++) {
+            PeerAccessibleMemory buf = new PeerAccessibleMemory(size);
+            memArray[i] = new Memory(size);
+        }
+        return memArray;
     }
 
     private void initialize() {
@@ -180,14 +161,14 @@ public class LinuxFsSpi extends SpiBase implements Spi {
 
         IntByReference intPtr = new IntByReference();
         int ret = libc.ioctl(fd, SPI_IOC_RD_MODE32, intPtr);
-        if(ret != 0) {
+        if (ret != 0) {
             libc.close(fd);
             throw new RuntimeException("Could not read SPI mode.");
         }
 
         // if 'flags' were provided error
-        if(config().flags() != null){
-            throw new IOException("Unsupported SPI Pi5 parameter flags" );
+        if (config().flags() != null) {
+            throw new IOException("Unsupported SPI Pi5 parameter flags");
         }
         switch (config().mode()) {
             case MODE_0:
@@ -205,21 +186,21 @@ public class LinuxFsSpi extends SpiBase implements Spi {
         }
 
         ret = libc.ioctl(fd, SPI_IOC_WR_MODE32, intPtr);
-        if(ret != 0) {
+        if (ret != 0) {
             libc.close(fd);
             throw new RuntimeException("Could not write SPI mode..");
         }
 
         intPtr.setValue(config().baud());
         ret = libc.ioctl(fd, SPI_IOC_RD_MAX_SPEED_HZ, intPtr);
-        if(ret != 0) {
+        if (ret != 0) {
             libc.close(fd);
             throw new RuntimeException("Could not read the SPI max speed.");
         }
 
         intPtr.setValue(config().baud());
         ret = libc.ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, intPtr);
-        if(ret != 0) {
+        if (ret != 0) {
             libc.close(fd);
             throw new RuntimeException("Could not write the SPI max speed.");
         }
@@ -227,14 +208,14 @@ public class LinuxFsSpi extends SpiBase implements Spi {
         // Bits per word
         intPtr.setValue(BITS8);
         ret = libc.ioctl(fd, SPI_IOC_WR_BITS_PER_WORD, intPtr);
-        if(ret != 0) {
+        if (ret != 0) {
             libc.close(fd);
             throw new RuntimeException("Could not write the SPI BITS per write.");
         }
         // Bits per word
         intPtr.setValue(BITS8);
         ret = libc.ioctl(fd, SPI_IOC_RD_BITS_PER_WORD, intPtr);
-        if(ret != 0) {
+        if (ret != 0) {
             libc.close(fd);
             throw new RuntimeException("Could not write the SPI BITS per read.");
         }
@@ -242,17 +223,17 @@ public class LinuxFsSpi extends SpiBase implements Spi {
         // BIT shift direction
         intPtr.setValue(config().readLsbFirst());
         ret = libc.ioctl(fd, SPI_IOC_RD_LSB_FIRST, intPtr);
-        if(ret != 0) {
+        if (ret != 0) {
             libc.close(fd);
             throw new RuntimeException("Could not write the SPI SHIFT read.");
         }
         intPtr.setValue(config().writeLsbFirst());
         ret = libc.ioctl(fd, SPI_IOC_WR_LSB_FIRST, intPtr);
-        if(ret != 0) {
+        if (ret != 0) {
             libc.close(fd);
             throw new RuntimeException("Could not write the SPI SHIFT write.");
         }
-   }
+    }
 
     @Override
     public void close() {
@@ -279,8 +260,7 @@ public class LinuxFsSpi extends SpiBase implements Spi {
         if (ret < 0) {
             logger.error("Could not write SPI message. ret {}, error: {}", ret, Native.getLastError());
             numberOfBytes = -1;
-        }
-        else {
+        } else {
             buf.read(0, read, readOffset, numberOfBytes);
         }
 
@@ -294,8 +274,7 @@ public class LinuxFsSpi extends SpiBase implements Spi {
         byte[] buf = new byte[1];
         if (read(buf, 0, 1) == 1) {
             return buf[0];
-        }
-        else {
+        } else {
             return -1;
         }
     }
@@ -316,7 +295,7 @@ public class LinuxFsSpi extends SpiBase implements Spi {
         if (ret < 0) {
             logger.error("Could not write SPIIOC  message. ret {}, error: {}", ret, Native.getLastError());
             length = -1;
-        }else{
+        } else {
             buf.read(0, read, offset, length);
         }
 
@@ -327,22 +306,21 @@ public class LinuxFsSpi extends SpiBase implements Spi {
 
     @Override
     public int write(byte b) {
-        return write(new byte[] {b}, 0, 1);
+        return write(new byte[]{b}, 0, 1);
     }
-
 
     /**
      * {@inheritDoc}
      * write
-     *
-     *   SPI_BUFFSIZ most often is set to 4096.  See initialize()
+     * <p>
+     * SPI_BUFFSIZ most often is set to 4096.  See initialize()
      * This implementation can write blocks greater than 4096 byte
      * 'however', read and understand how this is accomplished.
-     *
+     * <p>
      * A write of data no greater than 4096 bytes is accomplished with
      * a single SPI write operation.
      * So CE line low, write bytes, CE line high
-     *
+     * <p>
      * A write greater than 4096 bytes will be segmented to multiple writes
      * each 4096  bytes in length, the last write is the MOD value.
      * So, CE line low, write first 4096 bytes CE line high.  This
@@ -353,8 +331,7 @@ public class LinuxFsSpi extends SpiBase implements Spi {
      * application keep the CE pin low during the duration of the call to
      * spi,write.
      *
-     *
-     * @param data data array of bytes to be written
+     * @param data   data array of bytes to be written
      * @param offset offset in data buffer to start at
      * @param length number of bytes to be written
      * @return
@@ -391,6 +368,75 @@ public class LinuxFsSpi extends SpiBase implements Spi {
         }
 
         return length;
+    }
+
+    @Override
+    public int registerRead(byte[] write, int writeOffset, int writeNumberOfBytes, short writeDelayUsec, byte[] read, int readOffset, int readNumberOfBytes, short readDelayUsec) {
+        final int firstRecord = 0;
+        final int secondRecord = 1;
+        final int totalRecords = 2;
+
+        Objects.checkFromIndexSize(writeOffset, writeNumberOfBytes, write.length);
+        Objects.checkFromIndexSize(readOffset, readNumberOfBytes, read.length);
+        spi_ioc_transfer[] transferArray = getTransferArray(totalRecords);
+        PeerAccessibleMemory txBuf = new PeerAccessibleMemory(readNumberOfBytes);
+        PeerAccessibleMemory rxBuf = new PeerAccessibleMemory(readNumberOfBytes);
+
+           //    PeerAccessible
+      //  Memory writeBuf = peerArray[firstRecord];//new PeerAccessibleMemory(SPI_BUFFSIZ);
+        txBuf.write(0, write, 0, writeNumberOfBytes);
+        spi_ioc_transfer txEntry = transferArray[firstRecord]; //new spi_ioc_transfer();
+
+        // set fields in the tx transfer msg
+        txEntry.tx_buf = txBuf.getPeer();
+        txEntry.rx_buf = 0;
+        txEntry.bits_per_word = BITS8;
+        txEntry.speed_hz = config.baud();
+        txEntry.delay_usecs = writeDelayUsec;
+        txEntry.cs_change = 0;
+        txEntry.len = writeNumberOfBytes;
+
+          // RX entry
+        spi_ioc_transfer rxEntry = transferArray[1];
+        rxEntry.rx_buf = rxBuf.getPeer();
+        rxEntry.tx_buf = 0;
+        rxEntry.bits_per_word = BITS8;
+        rxEntry.speed_hz = config.baud();
+        rxEntry.delay_usecs = readDelayUsec;
+        rxEntry.cs_change = 0;
+        rxEntry.len = readNumberOfBytes;
+
+        int ret = libc.ioctl(fd, SPI_IOC_MESSAGE(totalRecords), (Object) transferArray);
+
+        logger.trace("[SPI::RegRead] <- Number bytes read {} ", ret);
+        if (ret < 0) {
+            logger.error("Could not write SPI message. ret {}, error: {}", ret, Native.getLastError());
+        }
+        rxBuf.read(0, read, readOffset, readNumberOfBytes);
+
+        return readNumberOfBytes;
+    }
+
+    @Structure.FieldOrder({"tx_buf", "rx_buf",
+        "len", "speed_hz",
+        "delay_usecs", "bits_per_word", "cs_change", "tx_nbits", "rx_nbits", "word_delay_usecs", "pad"})
+    public static class spi_ioc_transfer extends Structure {
+        public long tx_buf;
+        public long rx_buf;
+
+        public int len;
+        public int speed_hz;
+
+        public short delay_usecs;
+        public byte bits_per_word;
+        public byte cs_change;
+        public byte tx_nbits;
+        public byte rx_nbits;
+        public byte word_delay_usecs;
+        public byte pad;
+
+        public static class ByValue extends spi_ioc_transfer implements Structure.ByValue {
+        }
     }
 
     /**

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/spi/LinuxFsSpi.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/spi/LinuxFsSpi.java
@@ -242,11 +242,33 @@ public class LinuxFsSpi extends SpiBase implements Spi {
         super.close();
     }
 
-    @Override
-    public int transfer(byte[] write, int writeOffset, byte[] read, int readOffset, int numberOfBytes) {
+
+   @Override
+    /**
+     * This function transfers (writes/reads simultaneously) multiple bytes with the SPI
+     * device associated with the handle.  Write data is taken from the 'write' byte array
+     * from the given 'writeOffset' index to the specified length ('numberOfBytes').  Data
+     * read from the SPI device is then copied to the 'read' byte array at the given 'readOffset'
+     * using the same length ('numberOfBytes').  Both the 'write' and 'read' byte arrays must
+     * be at least the size of the defined 'numberOfBytes' + their corresponding offsets.
+     *
+     * @param write the array of bytes to write to the SPI device
+     * @param writeOffset the starting offset position in the provided 'write' buffer to
+     *                    start writing to the SPI device from.
+     * @param read the array of bytes to store read data in from the SPI device
+     * @param readOffset the starting offset position in the provided 'read' buffer to place
+     *                   data bytes read from the SPI device.
+     * @param numberOfBytes the number of bytes to transfer/exchange (read &amp; read))
+     * @return Returns 0 if OK, -1 on error. Error details available in last errno or
+     *                   rerunning the program with log level "TRACE",
+     *                   See : https://www.pi4j.com/documentation/logging/
+     *
+     */
+     public int transfer(byte[] write, int writeOffset, byte[] read, int readOffset, int numberOfBytes) {
         PeerAccessibleMemory buf = new PeerAccessibleMemory(numberOfBytes);
         buf.write(0, write, writeOffset, numberOfBytes);
 
+        int rCode = 0 ;
         // According to the docs you can use the same buffer for tx/rx.
         spi_ioc_transfer transfer = new spi_ioc_transfer();
         transfer.tx_buf = buf.getPeer();
@@ -259,14 +281,14 @@ public class LinuxFsSpi extends SpiBase implements Spi {
         int ret = libc.ioctl(fd, SPI_IOC_MESSAGE(1), transfer);
         if (ret < 0) {
             logger.error("Could not write SPI message. ret {}, error: {}", ret, Native.getLastError());
-            numberOfBytes = -1;
+            rCode  = -1;
         } else {
             buf.read(0, read, readOffset, numberOfBytes);
         }
 
         buf.close();
 
-        return numberOfBytes;
+        return rCode;
     }
 
     @Override
@@ -334,12 +356,16 @@ public class LinuxFsSpi extends SpiBase implements Spi {
      * @param data   data array of bytes to be written
      * @param offset offset in data buffer to start at
      * @param length number of bytes to be written
-     * @return
+     * @return Returns 0 if OK, -1 on error. Error details available in last errno or
+     *                   rerunning the program with log level "TRACE",
+     *                   See : https://www.pi4j.com/documentation/logging/
+     *
      */
     @Override
     public int write(byte[] data, int offset, int length) {
         Objects.checkFromIndexSize(offset, length, data.length);
 
+        int rCode = 0;
         int position = offset;
         int dataEnd = offset + length;
         PeerAccessibleMemory buf = new PeerAccessibleMemory(SPI_BUFFSIZ);
@@ -361,22 +387,23 @@ public class LinuxFsSpi extends SpiBase implements Spi {
             logger.trace("[SPI::WRITE] <- Number bytes {} ", ret);
             if (ret < 0) {
                 logger.error("Could not write SPI message. ret {}, error: {}", ret, Native.getLastError());
-                length = 0;
+                rCode = -1;
                 break;
             }
             position += chunkLength;
         }
 
-        return length;
+        return rCode;
     }
 
     @Override
-    public int writeRead(byte[] write, int writeOffset, int writeNumberOfBytes, short writeDelayUsec, byte[] read, int readOffset, int readNumberOfBytes, short readDelayUsec) {
+    public void writeThenRead(byte[] write, int writeOffset, int writeLength, short writeDelayUsec, byte[] read, int readOffset, int readNumberOfBytes, short readDelayUsec) {
         final int firstRecord = 0;
         final int secondRecord = 1;
         final int totalRecords = 2;
 
-        Objects.checkFromIndexSize(writeOffset, writeNumberOfBytes, write.length);
+
+        Objects.checkFromIndexSize(writeOffset, writeLength, write.length);
         Objects.checkFromIndexSize(readOffset, readNumberOfBytes, read.length);
         spi_ioc_transfer[] transferArray = getTransferArray(totalRecords);
         PeerAccessibleMemory txBuf = new PeerAccessibleMemory(readNumberOfBytes);
@@ -384,7 +411,7 @@ public class LinuxFsSpi extends SpiBase implements Spi {
 
            //    PeerAccessible
       //  Memory writeBuf = peerArray[firstRecord];//new PeerAccessibleMemory(SPI_BUFFSIZ);
-        txBuf.write(0, write, 0, writeNumberOfBytes);
+        txBuf.write(0, write, 0, writeLength);
         spi_ioc_transfer txEntry = transferArray[firstRecord]; //new spi_ioc_transfer();
 
         // set fields in the tx transfer msg
@@ -394,10 +421,10 @@ public class LinuxFsSpi extends SpiBase implements Spi {
         txEntry.speed_hz = config.baud();
         txEntry.delay_usecs = writeDelayUsec;
         txEntry.cs_change = 0;
-        txEntry.len = writeNumberOfBytes;
+        txEntry.len = writeLength;
 
           // RX entry
-        spi_ioc_transfer rxEntry = transferArray[1];
+        spi_ioc_transfer rxEntry = transferArray[secondRecord];
         rxEntry.rx_buf = rxBuf.getPeer();
         rxEntry.tx_buf = 0;
         rxEntry.bits_per_word = BITS8;
@@ -411,10 +438,10 @@ public class LinuxFsSpi extends SpiBase implements Spi {
         logger.trace("[SPI::RegRead] <- Number bytes read {} ", ret);
         if (ret < 0) {
             logger.error("Failed ioctl SPI message. ret {}, error: {}", ret, Native.getLastError());
+            throw new IOException(String.valueOf(Native.getLastError()));
         }
         rxBuf.read(0, read, readOffset, readNumberOfBytes);
 
-        return readNumberOfBytes;
     }
 
     @Structure.FieldOrder({"tx_buf", "rx_buf",


### PR DESCRIPTION
Addition to the SPI interface, supported in linuxfs but not pigpio, and not in ffm as of yet.

Allows SPI devices that require a write to setup the chip and then the following read.  If there is a required delay between the write and read or after the read and before the CS is released they are each available as parameter.






Review, the many space additions were not seen at the user level in gitk. Appears the git push initiated a cleanup step with different rules. 