### PR TITLE
Revert deprecated Serial implementations

### DIFF
--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_Serial.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/PiGpio_Serial.java
@@ -37,7 +37,6 @@ import java.nio.charset.StandardCharsets;
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
  */
-@Deprecated(forRemoval = true)
 public interface PiGpio_Serial {
 
     /**

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/internal/PIGPIO.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/internal/PIGPIO.java
@@ -383,7 +383,6 @@ public class PIGPIO {
      * @param data_bits a int.
      * @return a int.
      */
-    @Deprecated(forRemoval = true)
     public static native int gpioSerialReadOpen(int user_gpio, int baud, int data_bits);
 
     /**
@@ -393,7 +392,6 @@ public class PIGPIO {
      * @param invert    a int.
      * @return a int.
      */
-    @Deprecated(forRemoval = true)
     public static native int gpioSerialReadInvert(int user_gpio, int invert);
 
     /**
@@ -404,7 +402,6 @@ public class PIGPIO {
      * @param bufSize   a int.
      * @return a int.
      */
-    @Deprecated(forRemoval = true)
     public static native int gpioSerialRead(int user_gpio, byte[] buffer, int bufSize);
 
     /**
@@ -413,7 +410,6 @@ public class PIGPIO {
      * @param user_gpio a int.
      * @return a int.
      */
-    @Deprecated(forRemoval = true)
     public static native int gpioSerialReadClose(int user_gpio);
 
     /**
@@ -881,7 +877,6 @@ public class PIGPIO {
      * @param serFlags a int.
      * @return a int.
      */
-    @Deprecated(forRemoval = true)
     public static native int serOpen(String sertty, int baud, int serFlags);
 
     /**
@@ -891,7 +886,6 @@ public class PIGPIO {
      * @param baud   a int.
      * @return a int.
      */
-    @Deprecated(forRemoval = true)
     public static int serOpen(String sertty, int baud) {
         return serOpen(sertty, baud, 0);
     }
@@ -902,7 +896,6 @@ public class PIGPIO {
      * @param handle a int.
      * @return a int.
      */
-    @Deprecated(forRemoval = true)
     public static native int serClose(int handle);
 
     /**
@@ -912,7 +905,6 @@ public class PIGPIO {
      * @param bVal   a byte.
      * @return a int.
      */
-    @Deprecated(forRemoval = true)
     public static native int serWriteByte(int handle, byte bVal);
 
     /**
@@ -921,7 +913,6 @@ public class PIGPIO {
      * @param handle a int.
      * @return a int.
      */
-    @Deprecated(forRemoval = true)
     public static native int serReadByte(int handle);
 
     /**
@@ -933,7 +924,6 @@ public class PIGPIO {
      * @param count  a int.
      * @return a int.
      */
-    @Deprecated(forRemoval = true)
     public static native int serWrite(int handle, byte[] buf, int offset, int count);
 
     /**
@@ -944,7 +934,6 @@ public class PIGPIO {
      * @param count  a int.
      * @return a int.
      */
-    @Deprecated(forRemoval = true)
     public static int serWrite(int handle, byte[] buf, int count) {
         return serWrite(handle, buf, 0, count);
     }
@@ -958,7 +947,6 @@ public class PIGPIO {
      * @param count  a int.
      * @return a int.
      */
-    @Deprecated(forRemoval = true)
     public static native int serRead(int handle, byte[] buf, int offset, int count);
 
     /**
@@ -969,7 +957,6 @@ public class PIGPIO {
      * @param count  a int.
      * @return a int.
      */
-    @Deprecated(forRemoval = true)
     public static int serRead(int handle, byte[] buf, int count) {
         return serRead(handle, buf, 0, count);
     }
@@ -980,7 +967,6 @@ public class PIGPIO {
      * @param handle a int.
      * @return a int.
      */
-    @Deprecated(forRemoval = true)
     public static native int serDataAvailable(int handle);
 
     /**
@@ -989,7 +975,6 @@ public class PIGPIO {
      * @param handle a int.
      * @return a int.
      */
-    @Deprecated(forRemoval = true)
     public static native int serDrain(int handle);
 
     /**

--- a/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/test/TestSerial.java
+++ b/libraries/pi4j-library-pigpio/src/main/java/com/pi4j/library/pigpio/test/TestSerial.java
@@ -40,7 +40,6 @@ import java.util.Random;
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
  */
-@Deprecated(forRemoval = true)
 public class TestSerial {
 
     private static final Logger logger = LoggerFactory.getLogger(TestSerial.class);

--- a/pi4j-core/src/main/java/com/pi4j/io/IOType.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOType.java
@@ -61,7 +61,6 @@ public enum IOType {
     PWM(PwmProvider.class, Pwm.class, PwmConfig.class, PwmConfigBuilder.class),
     I2C(I2CProvider.class, com.pi4j.io.i2c.I2C.class, I2CConfig.class, I2CConfigBuilder.class),
     SPI(SpiProvider.class, Spi.class, I2CConfig.class, I2CConfigBuilder.class),
-    @Deprecated(forRemoval = true)
     SERIAL(SerialProvider.class, Serial.class, SerialConfig.class, SerialConfigBuilder.class);
 
     private Class<? extends Provider> providerClass;

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/serial/PiGpioSerial.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/serial/PiGpioSerial.java
@@ -43,7 +43,6 @@ import com.pi4j.library.pigpio.PiGpioMode;
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
  */
-@Deprecated(forRemoval = true)
 public class PiGpioSerial extends SerialBase implements Serial {
 
     protected final PiGpio piGpio;

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/serial/PiGpioSerialProvider.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/serial/PiGpioSerialProvider.java
@@ -37,7 +37,6 @@ import com.pi4j.plugin.pigpio.PiGpioPlugin;
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
  */
-@Deprecated(forRemoval = true)
 public interface PiGpioSerialProvider extends SerialProvider {
     /**
      * Constant <code>NAME="PiGpioPlugin.SERIAL_PROVIDER_NAME"</code>

--- a/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/serial/PiGpioSerialProviderImpl.java
+++ b/plugins/pi4j-plugin-pigpio/src/main/java/com/pi4j/plugin/pigpio/provider/serial/PiGpioSerialProviderImpl.java
@@ -39,7 +39,6 @@ import com.pi4j.library.pigpio.PiGpio;
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
  */
-@Deprecated(forRemoval = true)
 public class PiGpioSerialProviderImpl extends SerialProviderBase implements PiGpioSerialProvider {
 
     final PiGpio piGpio;

--- a/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/serial/RpiSerial.java
+++ b/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/serial/RpiSerial.java
@@ -38,7 +38,6 @@ import com.pi4j.io.serial.SerialProvider;
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
  */
-@Deprecated(forRemoval = true)
 public class RpiSerial extends SerialBase implements Serial {
 
     /**

--- a/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/serial/RpiSerialProvider.java
+++ b/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/serial/RpiSerialProvider.java
@@ -36,7 +36,6 @@ import com.pi4j.plugin.raspberrypi.RaspberryPi;
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
  */
-@Deprecated(forRemoval = true)
 public interface RpiSerialProvider extends SerialProvider {
     /**
      * Constant <code>NAME="RaspberryPi.SERIAL_PROVIDER_NAME"</code>

--- a/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/serial/RpiSerialProviderImpl.java
+++ b/plugins/pi4j-plugin-raspberrypi/src/main/java/com/pi4j/plugin/raspberrypi/provider/serial/RpiSerialProviderImpl.java
@@ -37,7 +37,6 @@ import com.pi4j.io.serial.SerialProviderBase;
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
  */
-@Deprecated(forRemoval = true)
 public class RpiSerialProviderImpl extends SerialProviderBase implements RpiSerialProvider {
 
     /**


### PR DESCRIPTION
As the FFM plugin will provide serial implementation, I propose to revert the earlier deprecations related to any serial functionality.

This was done in 2025-03-24 - V3.0.1
Related to discussion https://github.com/Pi4J/pi4j/discussions/308
