### PR TITLE
Correctly identify IOs in the registry based on bcm and/or bus and/or device and/or channel

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/config/Config.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/Config.java
@@ -10,7 +10,7 @@ package com.pi4j.config;
  * This file is part of the Pi4J project. More information about
  * this project can be found here:  https://pi4j.com/
  * **********************************************************************
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -30,23 +30,30 @@ import java.util.Map;
 /**
  * <p>Config interface.</p>
  *
+ * @param <CONFIG_TYPE>
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
- * @param <CONFIG_TYPE>
  */
 public interface Config<CONFIG_TYPE> {
-    /** Constant <code>ID_KEY="id"</code> */
+    /**
+     * Constant <code>ID_KEY="id"</code>
+     */
     String ID_KEY = "id";
-    /** Constant <code>NAME_KEY="name"</code> */
+    /**
+     * Constant <code>NAME_KEY="name"</code>
+     */
     String NAME_KEY = "name";
-    /** Constant <code>DESCRIPTION_KEY="description"</code> */
+    /**
+     * Constant <code>DESCRIPTION_KEY="description"</code>
+     */
     String DESCRIPTION_KEY = "description";
 
     /**
      * Underlying raw configuration properties.
+     *
      * @return a {@link Map} of {@link String},{@link String} of raw property keys and string values.
      */
-    Map<String,String> properties();
+    Map<String, String> properties();
 
     /**
      * <p>id.</p>
@@ -79,23 +86,40 @@ public interface Config<CONFIG_TYPE> {
      *
      * @return a {@link java.lang.String} object.
      */
-    default String getId(){
+    default String getId() {
         return this.id();
     }
+
     /**
      * <p>getName.</p>
      *
      * @return a {@link java.lang.String} object.
      */
-    default String getName(){
+    default String getName() {
         return this.name();
     }
+
     /**
      * <p>getDescription.</p>
      *
      * @return a {@link java.lang.String} object.
      */
-    default String getDescription(){
+    default String getDescription() {
         return this.description();
     }
+
+    /**
+     * Each IO Type has to provide a unique identifier.
+     * Depending on the type of device:
+     *
+     * <ul>
+     *     <li>GPIO: bcm</li>
+     *     <li>I2C: bus+address</li>
+     *     <li>SPI: bus+channel</li>
+     *     <li>PWM: bus+channel</li>
+     * </ul>
+     *
+     * @return Unique identifier.
+     */
+    int getUniqueIdentifier();
 }

--- a/pi4j-core/src/main/java/com/pi4j/config/ConfigBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/config/ConfigBase.java
@@ -35,9 +35,9 @@ import java.util.Map;
 /**
  * <p>ConfigBase class.</p>
  *
+ * @param <CONFIG_TYPE>
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
- * @param <CONFIG_TYPE>
  */
 public class ConfigBase<CONFIG_TYPE extends Config> implements Config<CONFIG_TYPE> {
 
@@ -45,12 +45,12 @@ public class ConfigBase<CONFIG_TYPE extends Config> implements Config<CONFIG_TYP
     protected String id = null;
     protected String name = null;
     protected String description = null;
-    protected Map<String,String> properties = new HashMap<>();
+    protected Map<String, String> properties = new HashMap<>();
 
     /**
      * PRIVATE CONSTRUCTOR
      */
-    protected ConfigBase(){
+    protected ConfigBase() {
     }
 
     /**
@@ -58,52 +58,70 @@ public class ConfigBase<CONFIG_TYPE extends Config> implements Config<CONFIG_TYP
      *
      * @param properties a {@link java.util.Map} object.
      */
-    protected ConfigBase(Map<String,String> properties){
+    protected ConfigBase(Map<String, String> properties) {
         // add all properties to this config object
         this.properties.putAll(properties);
 
         // load required 'id' property
-        if(properties.containsKey(ID_KEY))
+        if (properties.containsKey(ID_KEY))
             this.id = properties.get(ID_KEY);
 
         // load optional 'name' property
-        if(properties.containsKey(NAME_KEY))
+        if (properties.containsKey(NAME_KEY))
             this.name = properties.get(NAME_KEY);
 
         // load optional 'description' property
-        if(properties.containsKey(DESCRIPTION_KEY))
+        if (properties.containsKey(DESCRIPTION_KEY))
             this.description = properties.get(DESCRIPTION_KEY);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Map<String, String> properties() {
         return Collections.unmodifiableMap(this.properties);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String id() {
         return this.id;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String name() {
         return this.name;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String description() {
         return this.description;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void validate() {
-        if(StringUtil.isNullOrEmpty(this.id)){
+        if (StringUtil.isNullOrEmpty(this.id)) {
             throw new ConfigMissingRequiredKeyException(ID_KEY);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getUniqueIdentifier() {
+        return 0;
     }
 }

--- a/pi4j-core/src/main/java/com/pi4j/internal/IOCreator.java
+++ b/pi4j-core/src/main/java/com/pi4j/internal/IOCreator.java
@@ -45,7 +45,7 @@ import com.pi4j.io.spi.SpiConfig;
 import com.pi4j.io.spi.SpiConfigBuilder;
 
 public interface IOCreator {
-    
+
     <I extends IO> I create(IOConfig config, IOType type);
 
     <I extends IO> I create(String id);
@@ -57,7 +57,7 @@ public interface IOCreator {
     }
 
     default <I extends IO> I create(IOConfig config, Class<I> ioClass) {
-        return (ioClass.cast(create((IOConfig) config, IOType.getByIOClass(ioClass))));
+        return (ioClass.cast(create(config, IOType.getByIOClass(ioClass))));
     }
 
     default <I extends IO> I create(IOConfigBuilder builder, IOType ioType) {

--- a/pi4j-core/src/main/java/com/pi4j/io/IOConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/IOConfig.java
@@ -30,19 +30,23 @@ import com.pi4j.config.Config;
 /**
  * <p>IOConfig interface.</p>
  *
+ * @param <CONFIG_TYPE>
  * @author Robert Savage (<a href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  * @version $Id: $Id
- * @param <CONFIG_TYPE>
  */
 public interface IOConfig<CONFIG_TYPE> extends Config<CONFIG_TYPE> {
     String PLATFORM_KEY = "platform";
     String PROVIDER_KEY = "provider";
+
     String provider();
-    default String getProvider(){
+
+    default String getProvider() {
         return provider();
     }
+
     String platform();
-    default String getPlatform(){
+
+    default String getPlatform() {
         return platform();
     }
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioConfig.java
@@ -39,4 +39,14 @@ import com.pi4j.io.IOConfig;
  */
 public interface GpioConfig<CONFIG_TYPE extends Config> extends BusConfig<CONFIG_TYPE>, BcmConfig<CONFIG_TYPE>, IOConfig<CONFIG_TYPE> {
 
+    /**
+     * GPIO Device Identifier
+     * To be able to identify unique GPIO devices, an identifier is available which is based on the bcm value.
+     *
+     * @return Unique GPIO device identifier.
+     */
+    @Override
+    default int getUniqueIdentifier() {
+        return bcm();
+    }
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalInputConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalInputConfig.java
@@ -121,6 +121,14 @@ public class DefaultDigitalInputConfig
      * {@inheritDoc}
      */
     @Override
+    public int getUniqueIdentifier() {
+        return bcm();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public PullResistance pull() {
         return this.pullResistance;
     }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalOutputConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/impl/DefaultDigitalOutputConfig.java
@@ -122,6 +122,14 @@ public class DefaultDigitalOutputConfig
      * {@inheritDoc}
      */
     @Override
+    public int getUniqueIdentifier() {
+        return bcm();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public DigitalState shutdownState() {
         return this.shutdownState;
     }

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CConfig.java
@@ -62,7 +62,8 @@ public interface I2CConfig extends IOConfig<I2CConfig>, BusConfig<I2CConfig>, De
      *
      * @return Unique I2C device identifier.
      */
-    default int getIdentifier() {
+    @Override
+    default int getUniqueIdentifier() {
         return (bus() << 8) + device();
     }
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CConfig.java
@@ -55,4 +55,14 @@ public interface I2CConfig extends IOConfig<I2CConfig>, BusConfig<I2CConfig>, De
     static I2CConfigBuilder newBuilder(Context context) {
         return I2CConfigBuilder.newInstance(context);
     }
+
+    /**
+     * I2C Device Identifier
+     * To be able to identify unique I2C devices, an identifier is available which is based on the device and bus value.
+     *
+     * @return Unique I2C device identifier.
+     */
+    default int getIdentifier() {
+        return (bus() << 8) + device();
+    }
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CConfig.java
@@ -58,7 +58,7 @@ public interface I2CConfig extends IOConfig<I2CConfig>, BusConfig<I2CConfig>, De
 
     /**
      * I2C Device Identifier
-     * To be able to identify unique I2C devices, an identifier is available which is based on the device and bus value.
+     * To be able to identify unique I2C devices, an identifier is available which is based on the bus and device value.
      *
      * @return Unique I2C device identifier.
      */

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/DefaultI2CConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/DefaultI2CConfig.java
@@ -41,8 +41,8 @@ import java.util.Map;
  * @version $Id: $Id
  */
 public class DefaultI2CConfig
-        extends IOConfigBase<I2CConfig>
-        implements I2CConfig {
+    extends IOConfigBase<I2CConfig>
+    implements I2CConfig {
 
     // private configuration properties
     protected Integer bus = null;
@@ -52,7 +52,7 @@ public class DefaultI2CConfig
     /**
      * PRIVATE CONSTRUCTOR
      */
-    private DefaultI2CConfig(){
+    private DefaultI2CConfig() {
         super();
     }
 
@@ -64,25 +64,25 @@ public class DefaultI2CConfig
      *
      * @param properties a {@link java.util.Map} object.
      */
-    protected DefaultI2CConfig(Map<String,String> properties){
+    protected DefaultI2CConfig(Map<String, String> properties) {
         super(properties);
 
         // load (required) BUS property
-        if(properties.containsKey(BUS_KEY)){
+        if (properties.containsKey(BUS_KEY)) {
             this.bus = Integer.parseInt(properties.get(BUS_KEY));
         } else {
             throw new ConfigMissingRequiredKeyException(BUS_KEY);
         }
 
         // load (required) DEVICE property
-        if(properties.containsKey(DEVICE_KEY)){
+        if (properties.containsKey(DEVICE_KEY)) {
             this.device = Integer.parseInt(properties.get(DEVICE_KEY));
         } else {
             throw new ConfigMissingRequiredKeyException(DEVICE_KEY);
         }
 
         // i2c implementation
-        if(properties.containsKey(I2C_IMPLEMENTATION)){
+        if (properties.containsKey(I2C_IMPLEMENTATION)) {
             this.i2cImplementation = I2CImplementation.valueOf(properties.get(I2C_IMPLEMENTATION));
         } else {
             this.i2cImplementation = I2CImplementation.SMBUS;
@@ -94,16 +94,28 @@ public class DefaultI2CConfig
         this.description = StringUtil.setIfNullOrEmpty(this.description, "I2C-" + this.bus() + "." + this.device(), true);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Integer bus() {
         return this.bus;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Integer device() {
         return this.device;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getUniqueIdentifier() {
+        return (bus() << 8) + device();
     }
 
     @Override

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/PwmConfig.java
@@ -86,6 +86,17 @@ public interface PwmConfig extends BusConfig<PwmConfig>, ChannelConfig<PwmConfig
     Integer address();
 
     /**
+     * PWM Device Identifier
+     * To be able to identify unique PWM devices, an identifier is available which is based on the channel value.
+     *
+     * @return Unique SPI device identifier.
+     */
+    @Override
+    default int getUniqueIdentifier() {
+        return (bus() == null ? 0 : (bus() << 8)) + channel();
+    }
+
+    /**
      * Get the configured duty-cycle value as a decimal value that represents
      * the percentage of the ON vs OFF time of the PWM signal for each period.
      * The duty-cycle range is valid from 0 to 100 including factional values.

--- a/pi4j-core/src/main/java/com/pi4j/io/pwm/impl/DefaultPwmConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/pwm/impl/DefaultPwmConfig.java
@@ -166,6 +166,14 @@ public class DefaultPwmConfig
      * {@inheritDoc}
      */
     @Override
+    public int getUniqueIdentifier() {
+        return (bus == null ? 0 : (bus << 8)) + channel();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Integer dutyCycle() {
         return this.dutyCycle;
     }

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/Spi.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/Spi.java
@@ -387,17 +387,17 @@ public interface Spi extends IO<Spi, SpiConfig, SpiProvider>, AutoCloseable, IOD
     // ------------------------------------------------------------------------------------
     //  writeThenRead
     // ------------------------------------------------------------------------------------
+
     /**
      * This function writes bytes to the SPI device and then reads bytes from the device
      * Write data is taken from the 'buffer' byte array, data
      * read back from the SPI device is then copied to the 'read' byte array
      *
      * @param write the array of bytes to write to the SPI device
-
-     * @param read   Buffer to contain read data
+     * @param read  Buffer to contain read data
      */
-    default void  writeThenRead(byte[] write,  byte[] read) {
-         writeThenRead(write, 0, write.length, (short) 0, read, 0, read.length, (short) 0);
+    default void writeThenRead(byte[] write, byte[] read) {
+        writeThenRead(write, 0, write.length, (short) 0, read, 0, read.length, (short) 0);
     }
 
     /**
@@ -405,47 +405,44 @@ public interface Spi extends IO<Spi, SpiConfig, SpiProvider>, AutoCloseable, IOD
      * Write data is taken from the 'buffer' byte array, data
      * read back from the SPI device is then copied to the 'read' byte array
      *
-     * @param write the array of bytes to write to the SPI device
-     * @param writeLength
-     *               Number bytes written from buffer to the SPI
-     * @param read   Buffer to contain read data
-     * @param readlength the number of bytes to read (read &amp; read))
+     * @param write       the array of bytes to write to the SPI device
+     * @param writeLength Number bytes written from buffer to the SPI
+     * @param read        Buffer to contain read data
+     * @param readlength  the number of bytes to read (read &amp; read))
      */
-    default void writeThenRead(byte[] write, int writeLength,  byte[] read,  int readlength) {
+    default void writeThenRead(byte[] write, int writeLength, byte[] read, int readlength) {
         writeThenRead(write, 0, writeLength, (short) 0, read, 0, readlength, (short) 0);
     }
 
 
     /**
      * This function writes bytes to the SPI device and then reads bytes from the device.
-     *  Write data is taken from the 'buffer' byte array from the given 'writeOffset' index to
-     *  the specified 'writeLength' (number of bytes).
-     *  Data read back from the SPI device is then copied to the 'read' byte array starting
+     * Write data is taken from the 'buffer' byte array from the given 'writeOffset' index to
+     * the specified 'writeLength' (number of bytes).
+     * Data read back from the SPI device is then copied to the 'read' byte array starting
      * at the given 'readOffset' using the 'readLength' (number of bytes).  The 'buffer' and  'read' byte
      * array must be at least the size of their defined 'length' + 'offset'.
-     *
+     * <p>
      * In addition. both the write and read operation can provide a configurable delay
      * allowing the effected SPI chip to complete any processing. The write operation and the read
      * operation each have an individual delay value.
      *
-     * @param write              the array of bytes to write to the SPI device and to store read data
-     *                           back from the SPI device
-     * @param writeOffset        the starting offset position in the provided buffer to
-     *                           start writing to the SPI device from and the position
-     *                           used as the starting offset position to place data bytes
-     *                           read back from the SPI device.
-     * @param writeLength        Number of bytes written from write buffer
-     * @param writeDelayUsecs    Delay after SPI write record processed by kernel before the
-     *                           read SPI record is processed. Value in usecs.
-     * @param read               Buffer to contain read data
-     * @param readOffset         Offset within the read buffer to begin placing read data
-     * @param readLength         The number of bytes to transfer/exchange (read &amp; read))
-     * @param readDelayUsecs     Delay after SPI read record processed by kernel before the
-     *                           read SPI record is processed. Value in usecs.
+     * @param write           the array of bytes to write to the SPI device and to store read data
+     *                        back from the SPI device
+     * @param writeOffset     the starting offset position in the provided buffer to
+     *                        start writing to the SPI device from and the position
+     *                        used as the starting offset position to place data bytes
+     *                        read back from the SPI device.
+     * @param writeLength     Number of bytes written from write buffer
+     * @param writeDelayUsecs Delay after SPI write record processed by kernel before the
+     *                        read SPI record is processed. Value in usecs.
+     * @param read            Buffer to contain read data
+     * @param readOffset      Offset within the read buffer to begin placing read data
+     * @param readLength      The number of bytes to transfer/exchange (read &amp; read))
+     * @param readDelayUsecs  Delay after SPI read record processed by kernel before the
+     *                        read SPI record is processed. Value in usecs.
      */
-    default void writeThenRead(byte[] write, int writeOffset, int writeLength,  short writeDelayUsecs, byte[] read, int readOffset, int readLength,  short readDelayUsecs) {
+    default void writeThenRead(byte[] write, int writeOffset, int writeLength, short writeDelayUsecs, byte[] read, int readOffset, int readLength, short readDelayUsecs) {
         throw new IllegalStateException("writeThenRead Not supported in this provider. \n See https://www.pi4j.com/documentation/providers/");
     }
-
-
 }

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/SpiConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/SpiConfig.java
@@ -79,6 +79,16 @@ public interface SpiConfig extends ChannelConfig<SpiConfig>, IOConfig<SpiConfig>
     }
 
     /**
+     * SPI Device Identifier
+     * To be able to identify unique SPI devices, an identifier is available which is based on the bus and channel value.
+     *
+     * @return Unique SPI device identifier.
+     */
+    default int getIdentifier() {
+        return (bus().getBus() << 8) + channel();
+    }
+
+    /**
      * <p>baud.</p>
      *
      * @return a {@link java.lang.Integer} object.

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/SpiConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/SpiConfig.java
@@ -84,7 +84,8 @@ public interface SpiConfig extends ChannelConfig<SpiConfig>, IOConfig<SpiConfig>
      *
      * @return Unique SPI device identifier.
      */
-    default int getIdentifier() {
+    @Override
+    default int getUniqueIdentifier() {
         return (bus().getBus() << 8) + channel();
     }
 

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/impl/DefaultSpiConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/impl/DefaultSpiConfig.java
@@ -133,6 +133,14 @@ public class DefaultSpiConfig
      * {@inheritDoc}
      */
     @Override
+    public int getUniqueIdentifier() {
+        return (bus.getBus() << 8) + channel();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Integer baud() {
         return this.baud;
     }

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/impl/DefaultSpiConfig.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/impl/DefaultSpiConfig.java
@@ -116,9 +116,9 @@ public class DefaultSpiConfig
         }
 
         // define default property values if any are missing (based on the required address value)
-        this.id = StringUtil.setIfNullOrEmpty(this.id, "SPI-" + this.channel(), true);
-        this.name = StringUtil.setIfNullOrEmpty(this.name, "SPI-" + this.channel(), true);
-        this.description = StringUtil.setIfNullOrEmpty(this.description, "SPI-" + this.channel(), true);
+        this.id = StringUtil.setIfNullOrEmpty(this.id, "SPI-" + this.bus().getBus() + "." + this.channel(), true);
+        this.name = StringUtil.setIfNullOrEmpty(this.name, "SPI-" + this.bus().getBus() + "." + this.channel(), true);
+        this.description = StringUtil.setIfNullOrEmpty(this.description, "SPI-" + this.bus().getBus() + "." + this.channel(), true);
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/registry/Registry.java
+++ b/pi4j-core/src/main/java/com/pi4j/registry/Registry.java
@@ -58,12 +58,11 @@ public interface Registry extends Describable {
     /**
      * <p>exists.</p>
      *
-     * @param ioType  a {@link com.pi4j.io.IOType} object.
-     * @param address an int.
-     *
+     * @param ioType     a {@link com.pi4j.io.IOType} object.
+     * @param identifier an int. Depending on the type of device: bcm (GPIO), identifier (I2C), channel (PWM and SPI)
      * @return a boolean.
      */
-    boolean exists(IOType ioType, int address);
+    boolean exists(IOType ioType, int identifier);
 
     /**
      * <p>all.</p>
@@ -75,22 +74,23 @@ public interface Registry extends Describable {
     /**
      * <p>get.</p>
      *
-     * @param id a {@link java.lang.String} object.
+     * @param id  a {@link java.lang.String} object.
      * @param <T> a T object.
      * @return a T object.
      * @throws com.pi4j.io.exception.IOInvalidIDException if any.
-     * @throws com.pi4j.io.exception.IONotFoundException if any.
+     * @throws com.pi4j.io.exception.IONotFoundException  if any.
      */
     <T extends IO> T get(String id) throws IOInvalidIDException, IONotFoundException;
+
     /**
      * <p>get.</p>
      *
-     * @param id a {@link java.lang.String} object.
+     * @param id   a {@link java.lang.String} object.
      * @param type a {@link java.lang.Class} object.
-     * @param <T> a T object.
+     * @param <T>  a T object.
      * @return a T object.
      * @throws com.pi4j.io.exception.IOInvalidIDException if any.
-     * @throws com.pi4j.io.exception.IONotFoundException if any.
+     * @throws com.pi4j.io.exception.IONotFoundException  if any.
      */
     <T extends IO> T get(String id, Class<T> type) throws IOInvalidIDException, IONotFoundException;
 
@@ -98,10 +98,10 @@ public interface Registry extends Describable {
      * <p>allByType.</p>
      *
      * @param ioClass a {@link java.lang.Class} object.
-     * @param <T> a T object.
+     * @param <T>     a T object.
      * @return a {@link java.util.Map} object.
      */
-    default <T extends IO> Map<String, T> allByType(Class<T> ioClass){
+    default <T extends IO> Map<String, T> allByType(Class<T> ioClass) {
         // create a map <io-id, io-instance> of I/O instances that extend of the given IO class
         var result = new ConcurrentHashMap<String, T>();
         this.all().values().stream().filter(ioClass::isInstance).forEach(p -> {
@@ -114,10 +114,10 @@ public interface Registry extends Describable {
      * <p>allByIoType.</p>
      *
      * @param ioType a {@link com.pi4j.io.IOType} object.
-     * @param <P> a P object.
+     * @param <P>    a P object.
      * @return a {@link java.util.Map} object.
      */
-    default <P extends Provider> Map<String, ? extends IO> allByIoType(IOType ioType){
+    default <P extends Provider> Map<String, ? extends IO> allByIoType(IOType ioType) {
         return allByType(ioType.getIOClass());
     }
 
@@ -125,10 +125,10 @@ public interface Registry extends Describable {
      * <p>allByProvider.</p>
      *
      * @param providerClass a {@link java.lang.Class} object.
-     * @param <P> a P object.
+     * @param <P>           a P object.
      * @return a {@link java.util.Map} object.
      */
-    default <P extends Provider> Map<String, ? extends IO> allByProvider(Class<P> providerClass){
+    default <P extends Provider> Map<String, ? extends IO> allByProvider(Class<P> providerClass) {
         return allByIoType(IOType.getByProviderClass(providerClass));
     }
 
@@ -136,15 +136,15 @@ public interface Registry extends Describable {
      * <p>allByProvider.</p>
      *
      * @param providerId a {@link java.lang.String} object.
-     * @param <P> a P object.
+     * @param <P>        a P object.
      * @return a {@link java.util.Map} object.
      */
-    default <P extends Provider> Map<String, ? extends IO> allByProvider(String providerId){
+    default <P extends Provider> Map<String, ? extends IO> allByProvider(String providerId) {
 
         // create a map <io-id, io-instance> of providers that extend of the given io class
         var result = this.all().values().stream()
-                .filter(instance -> providerId.equalsIgnoreCase(((IO) instance).provider().id()))
-                .collect(Collectors.toMap(IO::id, c->c));
+            .filter(instance -> providerId.equalsIgnoreCase(((IO) instance).provider().id()))
+            .collect(Collectors.toMap(IO::id, c -> c));
 
         return Collections.unmodifiableMap(result);
     }
@@ -153,19 +153,19 @@ public interface Registry extends Describable {
      * <p>allByProvider.</p>
      *
      * @param providerId a {@link java.lang.String} object.
-     * @param ioClass a {@link java.lang.Class} object.
-     * @param <P> a P object.
-     * @param <T> a T object.
+     * @param ioClass    a {@link java.lang.Class} object.
+     * @param <P>        a P object.
+     * @param <T>        a T object.
      * @return a {@link java.util.Map} object.
      */
-    default <P extends Provider, T extends IO> Map<String, T> allByProvider(String providerId, Class<T> ioClass){
+    default <P extends Provider, T extends IO> Map<String, T> allByProvider(String providerId, Class<T> ioClass) {
         // create a map <io-id, io-instance> of providers that extend of the given io class
         var result = new ConcurrentHashMap<String, T>();
         this.all().values().stream()
-                .filter(instance -> providerId.equalsIgnoreCase(((IO) instance).provider().id()))
-                .filter(ioClass::isInstance).forEach(p -> {
-            result.put(p.id(), ioClass.cast(p));
-        });
+            .filter(instance -> providerId.equalsIgnoreCase(((IO) instance).provider().id()))
+            .filter(ioClass::isInstance).forEach(p -> {
+                result.put(p.id(), ioClass.cast(p));
+            });
         return Collections.unmodifiableMap(result);
     }
 
@@ -175,18 +175,19 @@ public interface Registry extends Describable {
      * @param instance a {@link com.pi4j.io.IO} object.
      * @return this
      * @throws com.pi4j.io.exception.IOAlreadyExistsException if any.
-     * @throws com.pi4j.io.exception.IOInvalidIDException if any.
+     * @throws com.pi4j.io.exception.IOInvalidIDException     if any.
      */
     Registry add(IO instance) throws IOAlreadyExistsException, IOInvalidIDException;
+
     /**
      * <p>remove.</p>
      *
-     * @param id a {@link java.lang.String} object.
+     * @param id  a {@link java.lang.String} object.
      * @param <T> a T object.
      * @return a T object.
-     * @throws com.pi4j.io.exception.IONotFoundException if any.
+     * @throws com.pi4j.io.exception.IONotFoundException  if any.
      * @throws com.pi4j.io.exception.IOInvalidIDException if any.
-     * @throws com.pi4j.io.exception.IOShutdownException if any.
+     * @throws com.pi4j.io.exception.IOShutdownException  if any.
      */
     <T extends IO> T remove(String id) throws IONotFoundException, IOInvalidIDException, IOShutdownException;
 
@@ -199,12 +200,12 @@ public interface Registry extends Describable {
 
         Map<String, ? extends IO> instances = all();
         Descriptor descriptor = Descriptor.create()
-                .category("REGISTRY")
-                .name("I/O Registered Instances")
-                .quantity((instances == null) ? 0 : instances.size())
-                .type(this.getClass());
+            .category("REGISTRY")
+            .name("I/O Registered Instances")
+            .quantity((instances == null) ? 0 : instances.size())
+            .type(this.getClass());
 
-        if(instances != null && !instances.isEmpty()) {
+        if (instances != null && !instances.isEmpty()) {
             instances.forEach((id, instance) -> {
                 descriptor.add(instance.describe());
             });

--- a/pi4j-core/src/main/java/com/pi4j/registry/impl/DefaultRuntimeRegistry.java
+++ b/pi4j-core/src/main/java/com/pi4j/registry/impl/DefaultRuntimeRegistry.java
@@ -107,13 +107,12 @@ public class DefaultRuntimeRegistry implements RuntimeRegistry {
                 break;
             }
             case I2CConfig i2cConfig: {
-                var identifier = (i2cConfig.bus() << 8) + i2cConfig.device();
-                if (exists(instance.type(), identifier)) {
+                if (exists(instance.type(), i2cConfig.getIdentifier())) {
                     throw new IOAlreadyExistsException("Bus " + i2cConfig.bus() + ", Device " + i2cConfig.device());
                 }
                 Set<Integer> usedAddresses = this.usedAddressesByIoType.computeIfAbsent(instance.type(),
                     k -> new HashSet<>());
-                usedAddresses.add(identifier);
+                usedAddresses.add(i2cConfig.getIdentifier());
                 break;
             }
             case SpiConfig spiConfig: {
@@ -214,12 +213,12 @@ public class DefaultRuntimeRegistry implements RuntimeRegistry {
     }
 
     private <T extends IO> void removeFromMap(T instance) {
-        if (!(instance.config() instanceof BcmConfig<?> addressConfig))
+        if (!(instance.config() instanceof BcmConfig<?> bcmConfig))
             return;
         Set<Integer> usedAddresses = this.usedAddressesByIoType.get(instance.type());
         if (usedAddresses == null)
             return;
-        usedAddresses.remove(addressConfig.bcm());
+        usedAddresses.remove(bcmConfig.bcm());
         if (usedAddresses.isEmpty())
             this.usedAddressesByIoType.remove(instance.type());
     }

--- a/pi4j-core/src/main/java/com/pi4j/registry/impl/DefaultRuntimeRegistry.java
+++ b/pi4j-core/src/main/java/com/pi4j/registry/impl/DefaultRuntimeRegistry.java
@@ -107,12 +107,13 @@ public class DefaultRuntimeRegistry implements RuntimeRegistry {
                 break;
             }
             case I2CConfig i2cConfig: {
-                if (exists(instance.type(), i2cConfig.bus())) {
-                    throw new IOAlreadyExistsException(i2cConfig.bus());
+                var identifier = (i2cConfig.bus() << 8) + i2cConfig.device();
+                if (exists(instance.type(), identifier)) {
+                    throw new IOAlreadyExistsException("Bus " + i2cConfig.bus() + ", Device " + i2cConfig.device());
                 }
                 Set<Integer> usedAddresses = this.usedAddressesByIoType.computeIfAbsent(instance.type(),
                     k -> new HashSet<>());
-                usedAddresses.add(i2cConfig.bus());
+                usedAddresses.add(identifier);
                 break;
             }
             case SpiConfig spiConfig: {

--- a/pi4j-core/src/main/java/com/pi4j/registry/impl/DefaultRuntimeRegistry.java
+++ b/pi4j-core/src/main/java/com/pi4j/registry/impl/DefaultRuntimeRegistry.java
@@ -116,12 +116,12 @@ public class DefaultRuntimeRegistry implements RuntimeRegistry {
                 break;
             }
             case SpiConfig spiConfig: {
-                if (exists(instance.type(), spiConfig.channel())) {
-                    throw new IOAlreadyExistsException(spiConfig.channel());
+                if (exists(instance.type(), spiConfig.getIdentifier())) {
+                    throw new IOAlreadyExistsException("Bus " + spiConfig.bus() + ", Channel " + spiConfig.channel());
                 }
                 Set<Integer> usedAddresses = this.usedAddressesByIoType.computeIfAbsent(instance.type(),
                     k -> new HashSet<>());
-                usedAddresses.add(spiConfig.channel());
+                usedAddresses.add(spiConfig.getIdentifier());
                 break;
             }
             default: {

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
@@ -33,6 +33,7 @@ import com.pi4j.io.gpio.digital.DigitalInput;
 import com.pi4j.io.gpio.digital.DigitalOutput;
 import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.pwm.Pwm;
+import com.pi4j.io.spi.Spi;
 import com.pi4j.registry.Registry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -170,5 +171,30 @@ class RegistryTest {
         var i2c1 = pi4j.create(I2C.newConfigBuilder(pi4j).bus(0).device(0x70).build());
         assertNotNull(i2c1);
         assertThrows(Pi4JException.class, () -> pi4j.create(I2C.newConfigBuilder(pi4j).bus(0).device(0x70).build()));
+    }
+
+    @Test
+    void testCreateMultipleSpi() {
+        var config1 = Spi.newConfigBuilder(pi4j).bus(1).channel(0x21).build();
+        var spi1 = pi4j.create(config1);
+        var config2 = Spi.newConfigBuilder(pi4j).bus(1).channel(0x70).build();
+        var spi2 = pi4j.create(config2);
+        var config3 = Spi.newConfigBuilder(pi4j).bus(2).channel(0x21).build();
+        var spi3 = pi4j.create(config3);
+        var config4 = Spi.newConfigBuilder(pi4j).bus(3).channel(0x70).build();
+        var spi4 = pi4j.create(config4);
+        assertAll(
+            () -> assertNotNull(spi1),
+            () -> assertNotNull(spi2),
+            () -> assertNotNull(spi3),
+            () -> assertNotNull(spi4)
+        );
+    }
+
+    @Test
+    void testCreateMultipleSpiWithSameIdentifierShouldFail() {
+        var spi1 = pi4j.create(Spi.newConfigBuilder(pi4j).bus(0).channel(0x70).build());
+        assertNotNull(spi1);
+        assertThrows(Pi4JException.class, () -> pi4j.create(Spi.newConfigBuilder(pi4j).bus(0).channel(0x70).build()));
     }
 }

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
@@ -80,15 +80,14 @@ class RegistryTest {
 
     @Test
     void testShutdownAndRecreate() throws Pi4JException {
-        var inputConfig = DigitalInput.newConfigBuilder(pi4j).id("DIN-3").name("DIN-3").bcm(3);
+        var config = DigitalInput.newConfigBuilder(pi4j).id("DIN-3").name("DIN-3").bcm(3);
 
         // create a new input, then shutdown
-        var input = pi4j.create(inputConfig);
-
+        var input = pi4j.create(config);
         input.close();
 
         // shouldn't fail when recreating
-        input = pi4j.create(inputConfig);
+        input = pi4j.create(config);
 
         // or shutting down
         input.close();
@@ -109,10 +108,12 @@ class RegistryTest {
         Registry registry = pi4j.registry();
         assertAll(
             // Test that we can find them by address
-            () -> assertTrue(registry.exists(IOType.PWM, pwm.getChannel()), "Should exist: PWM by address"),
-            () -> assertTrue(registry.exists(IOType.I2C, i2c.config().getIdentifier()), "Should exist: I2C by identifier"),
-            () -> assertTrue(registry.exists(IOType.DIGITAL_INPUT, input.bcm()), "Should exist: Digital Input by pin"),
-            () -> assertTrue(registry.exists(IOType.DIGITAL_OUTPUT, output.bcm()), "Should exist: Digital Output by pin"),
+            () -> assertTrue(registry.exists(IOType.PWM, pwm.config().getUniqueIdentifier()), "Should exist: PWM by unique identifier"),
+            () -> assertTrue(registry.exists(IOType.I2C, i2c.config().getUniqueIdentifier()), "Should exist: I2C by unique identifier"),
+            () -> assertTrue(registry.exists(IOType.DIGITAL_INPUT, input.config().getUniqueIdentifier()), "Should exist: Digital Input by unique identifier which should be identical to BCM"),
+            () -> assertTrue(registry.exists(IOType.DIGITAL_OUTPUT, output.config().getUniqueIdentifier()), "Should exist: Digital Output by unique identifier which should be identical to BCM"),
+            () -> assertTrue(registry.exists(IOType.DIGITAL_INPUT, input.bcm()), "Should exist: Digital Input by BCM"),
+            () -> assertTrue(registry.exists(IOType.DIGITAL_OUTPUT, output.bcm()), "Should exist: Digital Output by BCM"),
 
             // and also by ID
             () -> assertTrue(registry.exists(pwm.id()), "Should exist: PWM by ID"),

--- a/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
+++ b/pi4j-test/src/test/java/com/pi4j/test/registry/RegistryTest.java
@@ -102,17 +102,20 @@ class RegistryTest {
         // create I/O instances
         var input = pi4j.create(inputConfig);
         var output = pi4j.create(outputConfig);
+        var i2c = pi4j.create(I2C.newConfigBuilder(pi4j).bus(0).device(0x70).build());
         var pwm = pi4j.create(pwmConfig);
 
         Registry registry = pi4j.registry();
         assertAll(
             // Test that we can find them by address
             () -> assertTrue(registry.exists(IOType.PWM, pwm.getChannel()), "Should exist: PWM by address"),
+            () -> assertTrue(registry.exists(IOType.I2C, i2c.config().getIdentifier()), "Should exist: I2C by identifier"),
             () -> assertTrue(registry.exists(IOType.DIGITAL_INPUT, input.bcm()), "Should exist: Digital Input by pin"),
             () -> assertTrue(registry.exists(IOType.DIGITAL_OUTPUT, output.bcm()), "Should exist: Digital Output by pin"),
 
             // and also by ID
             () -> assertTrue(registry.exists(pwm.id()), "Should exist: PWM by ID"),
+            () -> assertTrue(registry.exists(i2c.id()), "Should exist: I2C by ID"),
             () -> assertTrue(registry.exists(input.id()), "Should exist: Digital Input by ID"),
             () -> assertTrue(registry.exists(output.id()), "Should exist: Digital Output by ID")
         );


### PR DESCRIPTION
Current implementation doesn't except multiple I2C devices on the same bus.