### PR TITLE
Change pulse so it always returns to the inverse of the activation state

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutputBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/digital/DigitalOutputBase.java
@@ -102,7 +102,7 @@ public abstract class DigitalOutputBase extends DigitalBase<DigitalOutput, Digit
         }
 
         // end the pulse state
-        toggle();
+        this.state(DigitalState.getInverseState(state));
 
         // invoke callback if one was defined
         if (callback != null) {


### PR DESCRIPTION
On DigitalOutput, the original implementation toggles the activation on pulse.
This is problematic especially when using the async version of the function.
If two requests collide, it can produce  a state where the original state of the output is inverted when two pulse calls are made.

e.g.
async pulse(...);
async pulse(...);

Original state is LOW
First call changes state to HIGH
First call timeout
Second call changes state to HIGH
Second call timeout
First call changes state to LOW (inverts current)
Second call inverts state so output is HIGH

imo this is should not be the expected behavior
