### PR TITLE
Use correct path for unexport

### DIFF
--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/PwmFFMHardware.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/PwmFFMHardware.java
@@ -162,8 +162,8 @@ public class PwmFFMHardware extends PwmBase implements Pwm {
             return super.shutdownInternal(context);
         }
 
-        var exportFd = file.open(CHIP_PATH + bus + CHIP_UNEXPORT_PATH, FileFlag.O_WRONLY);
-        file.write(exportFd, getByteContent(channel));
+        var exportFd = file.open(CHIP_PATH + channel + CHIP_UNEXPORT_PATH, FileFlag.O_WRONLY);
+        file.write(exportFd, getByteContent(bus));
         file.close(exportFd);
 
         return this;


### PR DESCRIPTION
This PR intends to resolve an issue described by issue https://github.com/Pi4J/pi4j/issues/554

--- 

The problem appears to be due to confusion over the terms `bus` and `channel` and brings the `unexport` inline with their usage in the constructor: https://github.com/Pi4J/pi4j/blob/75df994e4a18c65c2994563392cf7a350f51fea5/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/pwm/PwmFFMHardware.java#L49

I understand that there are efforts elsewhere to address PWM confusions. This PR simply solves the issue for the current nomenclature. The long-term fix will no doubt be provided in response to https://github.com/Pi4J/pi4j/issues/551