### PR TITLE
Convert write(byte[]) back to writer(byte...)

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/SerialCircuitIO.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/SerialCircuitIO.java
@@ -34,7 +34,7 @@ public interface SerialCircuitIO extends AutoCloseable {
     }
 
     /** Writes the full byte array. Returns the buffer size for historical reasons. */
-    default int write(byte[] buffer) {
+    default int write(byte... buffer) {
         return write(buffer, 0, buffer.length);
     }
 

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2C.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2C.java
@@ -143,7 +143,7 @@ public interface I2C
     }
 
     @Override
-    default int write(byte[] data) {
+    default int write(byte... data) {
         return SerialCircuitIO.super.write(data);
     }
 

--- a/pi4j-core/src/main/java/com/pi4j/io/spi/Spi.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/spi/Spi.java
@@ -400,7 +400,7 @@ public interface Spi extends IO<Spi, SpiConfig, SpiProvider>, AutoCloseable, IOD
     }
 
     @Override
-    default int write(byte[] data) {
+    default int write(byte... data) {
         return SerialCircuitIO.super.write(data);
     }
 


### PR DESCRIPTION
I had changed this by accident when introducing SerialCircuitIO and it breaks drivers