### PR TITLE
new test for spi writeThenRead with offset. Fails to fix and FFM spi offset review/code  Required a fix in lunuxf…

### DIFF
--- a/pi4j-test/src/main/java/com/pi4j/test/Main.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/Main.java
@@ -97,7 +97,7 @@ public class Main {
             I2CWithOffsetTestCase.run(providerContext),
             SpiTestCase.run(providerContext),
             SpiWithOffsetTestCase.run(providerContext),
-         //   SpiWriteReadTestCase.run(providerContext), // requires manual CS across write/read operation
+            //SpiWriteReadTestCase.run(providerContext), // requires manual CS across write/read operation
             PWMTestCase.run(providerContext, 1, 50, 10),
             DigitalInputTestCase.run(providerContext),
             DigitalOutputTestCase.run(providerContext),

--- a/pi4j-test/src/main/java/com/pi4j/test/Main.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/Main.java
@@ -117,7 +117,7 @@ public class Main {
         logger.info("");
 
         // Output results
-        tests.forEach(t -> logger.info(t.log(logger)));
+        tests.forEach(t -> t.log(logger));
 
         providerContext.getContext().shutdown();
     }

--- a/pi4j-test/src/main/java/com/pi4j/test/Main.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/Main.java
@@ -106,6 +106,16 @@ public class Main {
             DigitalInputDebounceCountTestCase.run(providerContext)
         );
 
+        // Overall results
+        logger.info("");
+        logger.info("==============================================================");
+        logger.info("Test Results:");
+        logger.info("\tTotal Tests: {}", tests.size());
+        logger.info("\tPassed: {}", tests.stream().filter(TestResult::success).count());
+        logger.info("\tFailed: {}", tests.stream().filter(t -> !t.success()).count());
+        logger.info("==============================================================");
+        logger.info("");
+
         // Output results
         tests.forEach(t -> logger.info(t.getLogOutput()));
 

--- a/pi4j-test/src/main/java/com/pi4j/test/Main.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/Main.java
@@ -96,6 +96,8 @@ public class Main {
             I2CTestCase.run(providerContext),
             I2CWithOffsetTestCase.run(providerContext),
             SpiTestCase.run(providerContext),
+            SpiWithOffsetTestCase.run(providerContext),
+           //  SpiWriteReadTestCase.run(providerContext),  // requires logic analyzer verification
             PWMTestCase.run(providerContext, 1, 50, 10),
             DigitalInputTestCase.run(providerContext),
             DigitalOutputTestCase.run(providerContext),

--- a/pi4j-test/src/main/java/com/pi4j/test/Main.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/Main.java
@@ -109,7 +109,7 @@ public class Main {
         // Overall results
         logger.info("");
         logger.info("==============================================================");
-        logger.info("Test Results:");
+        logger.info("Test results with {}:", providerContext.getTestProvider().name());
         logger.info("\tTotal Tests: {}", tests.size());
         logger.info("\tPassed: {}", tests.stream().filter(TestResult::success).count());
         logger.info("\tFailed: {}", tests.stream().filter(t -> !t.success()).count());
@@ -117,7 +117,7 @@ public class Main {
         logger.info("");
 
         // Output results
-        tests.forEach(t -> logger.info(t.getLogOutput()));
+        tests.forEach(t -> logger.info(t.log(logger)));
 
         providerContext.getContext().shutdown();
     }

--- a/pi4j-test/src/main/java/com/pi4j/test/smoketest/SpiWithOffsetTestCase.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/smoketest/SpiWithOffsetTestCase.java
@@ -1,3 +1,32 @@
+/*
+ *
+ *
+ *  #%L
+ *  **********************************************************************
+ *  ORGANIZATION  :  Pi4J
+ *  PROJECT       :  Pi4J :: LIBRARY  :: Java Library (CORE)
+ *  FILENAME      :  SpiTestCaseWithOffset.java
+ *
+ *  This file is part of the Pi4J project. More information about
+ *  this project can be found here:  https://pi4j.com/
+ *  **********************************************************************
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  #L%
+ *
+ *
+ */
+
 package com.pi4j.test.smoketest;
 
 import com.pi4j.io.spi.Spi;
@@ -6,14 +35,14 @@ import com.pi4j.io.spi.SpiMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SpiTestCase extends TestCase {
+public class SpiWithOffsetTestCase  extends TestCase {
 
-    private static final Logger logger = LoggerFactory.getLogger(SpiTestCase.class);
+    private static final Logger logger = LoggerFactory.getLogger(SpiWithOffsetTestCase.class);
 
-    private static final String TEST_NAME = "SPI";
+    private static final String TEST_NAME = "SPI with offset";
 
     public static TestResult run(ProviderContext providerContext) {
-        logger.info("Starting SPI test");
+        logger.info("Starting SPI with offset test");
 
         Spi spi = null;
 
@@ -35,7 +64,7 @@ public class SpiTestCase extends TestCase {
             Thread.sleep(100);
 
             // Read data from 0xD0 and check if the expected value is received
-             byte idWriteThenRead = readSpiRegisterUsingWriteThenRead(spi, chipId);
+            byte idWriteThenRead = readSpiRegisterUsingWriteThenReadWithOffset(spi, chipId);
 
             logger.info("Device ID read: 0x{}, expected: 0x{} or 0x{}",
                 Integer.toHexString(idWriteThenRead),
@@ -57,15 +86,16 @@ public class SpiTestCase extends TestCase {
                 spi.close();
                 providerContext.getContext().registry().remove(spi.id());
             }
-
         }
     }
 
 
-    private static byte readSpiRegisterUsingWriteThenRead(Spi spi, int register) {
-        byte[] data = new byte[]{(byte) (0b10000000 | register)};
-        byte[] value = new byte[1];
-        spi.writeThenRead(data, 0, value);
-        return value[0];
+    private static byte readSpiRegisterUsingWriteThenReadWithOffset(Spi spi, int register) {
+         // Read data from 0xD0 with offset parameter
+        byte[] writeData = new byte[]{ 0x00, 0x00, (byte) (0b10000000 | register)};
+        byte[] readData = new byte[7];
+        spi.writeThenRead(writeData, 2, 1, 0, readData, 3, 1);
+        return  readData[3];
+
     }
 }

--- a/pi4j-test/src/main/java/com/pi4j/test/smoketest/SpiWriteReadTestCase.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/smoketest/SpiWriteReadTestCase.java
@@ -1,3 +1,32 @@
+/*
+ *
+ *
+ *  #%L
+ *  **********************************************************************
+ *  ORGANIZATION  :  Pi4J
+ *  PROJECT       :  Pi4J :: LIBRARY  :: Java Library (CORE)
+ *  FILENAME      :  SpiWriteReadTestCase.java
+ *
+ *  This file is part of the Pi4J project. More information about
+ *  this project can be found here:  https://pi4j.com/
+ *  **********************************************************************
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  #L%
+ *
+ *
+ */
+
 package com.pi4j.test.smoketest;
 
 import com.pi4j.io.spi.Spi;
@@ -6,14 +35,14 @@ import com.pi4j.io.spi.SpiMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SpiTestCase extends TestCase {
+public class SpiWriteReadTestCase   extends TestCase{
 
-    private static final Logger logger = LoggerFactory.getLogger(SpiTestCase.class);
+    private static final Logger logger = LoggerFactory.getLogger(SpiWriteReadTestCase.class);
 
-    private static final String TEST_NAME = "SPI";
+    private static final String TEST_NAME = "SPI Write Read";
 
     public static TestResult run(ProviderContext providerContext) {
-        logger.info("Starting SPI test");
+        logger.info("Starting SPI Write Read test");
 
         Spi spi = null;
 
@@ -35,7 +64,7 @@ public class SpiTestCase extends TestCase {
             Thread.sleep(100);
 
             // Read data from 0xD0 and check if the expected value is received
-             byte idWriteThenRead = readSpiRegisterUsingWriteThenRead(spi, chipId);
+            byte idWriteThenRead = readSpiRegisterUsingWriteRead(spi, chipId);
 
             logger.info("Device ID read: 0x{}, expected: 0x{} or 0x{}",
                 Integer.toHexString(idWriteThenRead),
@@ -57,15 +86,17 @@ public class SpiTestCase extends TestCase {
                 spi.close();
                 providerContext.getContext().registry().remove(spi.id());
             }
-
         }
     }
 
 
-    private static byte readSpiRegisterUsingWriteThenRead(Spi spi, int register) {
-        byte[] data = new byte[]{(byte) (0b10000000 | register)};
-        byte[] value = new byte[1];
-        spi.writeThenRead(data, 0, value);
-        return value[0];
+    private static byte readSpiRegisterUsingWriteRead(Spi spi, int register) {
+        // Read data from 0xD0 with offset parameter
+        byte[] writeData = new byte[]{ 0x00, 0x00, (byte) (0b10000000 | register)};
+        byte[] readData = new byte[7];
+        spi.write(writeData, 2, 1);
+        spi.read(readData, 3, 1);
+        return  readData[3];
+
     }
 }

--- a/pi4j-test/src/main/java/com/pi4j/test/smoketest/TestResult.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/smoketest/TestResult.java
@@ -3,7 +3,7 @@ package com.pi4j.test.smoketest;
 import org.slf4j.Logger;
 
 public record TestResult(String name, boolean success, String message) {
-    public String log(Logger logger) {
+    public void log(Logger logger) {
         logger.info("Test: {}", name);
         logger.info("\t{}", success ? "PASSED" : "FAILED");
         logger.info("\t{}", message);

--- a/pi4j-test/src/main/java/com/pi4j/test/smoketest/TestResult.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/smoketest/TestResult.java
@@ -5,6 +5,6 @@ public record TestResult(String name, boolean success, String message) {
         return "Test " + name + "\n"
             + (success ? "PASSED" : "FAILED") + "\n"
             + message + "\n"
-            + "==============================\n";
+            + "==============================\n\n";
     }
 }

--- a/pi4j-test/src/main/java/com/pi4j/test/smoketest/TestResult.java
+++ b/pi4j-test/src/main/java/com/pi4j/test/smoketest/TestResult.java
@@ -1,10 +1,12 @@
 package com.pi4j.test.smoketest;
 
+import org.slf4j.Logger;
+
 public record TestResult(String name, boolean success, String message) {
-    public String getLogOutput() {
-        return "Test " + name + "\n"
-            + (success ? "PASSED" : "FAILED") + "\n"
-            + message + "\n"
-            + "==============================\n\n";
+    public String log(Logger logger) {
+        logger.info("Test: {}", name);
+        logger.info("\t{}", success ? "PASSED" : "FAILED");
+        logger.info("\t{}", message);
+        logger.info("==============================================================");
     }
 }

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpi.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpi.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 public class FFMSpi extends SpiBase implements Spi {
     private static final Logger logger = LoggerFactory.getLogger(FFMSpi.class);
@@ -114,6 +115,9 @@ public class FFMSpi extends SpiBase implements Spi {
 
     @Override
     public void writeThenRead(byte[] write, int writeOffset, int writeLength, int readDelayNanos, byte[] read, int readOffset, int readLength) {
+        Objects.checkFromIndexSize(readOffset, readLength, read.length);
+        Objects.checkFromIndexSize(writeOffset, writeLength, write.length);
+
         var inputBuffer = new SpiTransferBuffer(write, new byte[0], writeLength, readDelayNanos / 1000);
         var outputBuffer = new SpiTransferBuffer(new byte[0], read, readLength, readDelayNanos / 1000);
 

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpi.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpi.java
@@ -90,7 +90,7 @@ public class FFMSpi extends SpiBase implements Spi {
         checkClosed();
         Objects.checkFromIndexSize(readOffset, numberOfBytes, read.length);
         Objects.checkFromIndexSize(writeOffset, numberOfBytes, write.length);
-        byte[] writeData = Arrays.copyOfRange(write, writeOffset, numberOfBytes + writeOffset);
+        var writeData = Arrays.copyOfRange(write, writeOffset, numberOfBytes + writeOffset);
 
         logger.trace("{} - Transferring data (length '{}')", path, numberOfBytes);
         if (write != null) {
@@ -145,7 +145,7 @@ public class FFMSpi extends SpiBase implements Spi {
     public void writeThenRead(byte[] write, int writeOffset, int writeLength, int readDelayNanos, byte[] read, int readOffset, int readLength) {
         Objects.checkFromIndexSize(readOffset, readLength, read.length);
         Objects.checkFromIndexSize(writeOffset, writeLength, write.length);
-        byte[] writeData = Arrays.copyOfRange(write, writeOffset, writeLength + writeOffset);
+        var writeData = Arrays.copyOfRange(write, writeOffset, writeLength + writeOffset);
         var inputBuffer = new SpiTransferBuffer(writeData, new byte[0], writeLength, readDelayNanos / 1000);
         var outputBuffer = new SpiTransferBuffer(new byte[0], read, readLength, readDelayNanos / 1000);
 

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpi.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpi.java
@@ -18,6 +18,7 @@ import com.pi4j.plugin.ffm.common.spi.SpiMultipleTransferBuffer;
 import com.pi4j.plugin.ffm.common.spi.SpiTransferBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -37,6 +38,9 @@ public class FFMSpi extends SpiBase implements Spi {
         FFMPermissionHelper.checkDevicePermissions(path, config);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Spi initialize(Context context) throws InitializeException {
         super.initialize(context);
@@ -69,18 +73,24 @@ public class FFMSpi extends SpiBase implements Spi {
         return this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Spi shutdownInternal(Context context) throws ShutdownException {
         FILE.close(spiFileDescriptor);
         return super.shutdownInternal(context);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int transfer(byte[] write, int writeOffset, byte[] read, int readOffset, int numberOfBytes) {
         checkClosed();
         Objects.checkFromIndexSize(readOffset, numberOfBytes, read.length);
         Objects.checkFromIndexSize(writeOffset, numberOfBytes, write.length);
-        byte[] writeData = Arrays.copyOfRange(write, writeOffset, numberOfBytes+writeOffset);
+        byte[] writeData = Arrays.copyOfRange(write, writeOffset, numberOfBytes + writeOffset);
 
         logger.trace("{} - Transferring data (length '{}')", path, numberOfBytes);
         if (write != null) {
@@ -90,37 +100,52 @@ public class FFMSpi extends SpiBase implements Spi {
         spiTransfer = IOCTL.call(spiFileDescriptor, Command.getSpiIocMessage(1), spiTransfer);
         var readBytes = spiTransfer.getRxBuffer();
         if (read != null) {
-            System.arraycopy(readBytes, 0, read,  readOffset, numberOfBytes);
+            System.arraycopy(readBytes, 0, read, readOffset, numberOfBytes);
             logger.trace("{} - Read buffer: {}", path, HexFormatter.format(read));
         }
         return readBytes.length;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int write(byte data) {
         return write(new byte[]{data}, 0, 1);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int write(byte[] data, int offset, int length) {
         return transfer(data, offset, new byte[data.length], 0, length);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void writeThenRead(byte[] write, byte[] read) {
         writeThenRead(write, 0, write.length, 0, read, 0, read.length);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void writeThenRead(byte[] write, int readDelayNanos, byte[] read) {
         writeThenRead(write, 0, write.length, readDelayNanos, read, 0, read.length);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void writeThenRead(byte[] write, int writeOffset, int writeLength, int readDelayNanos, byte[] read, int readOffset, int readLength) {
         Objects.checkFromIndexSize(readOffset, readLength, read.length);
         Objects.checkFromIndexSize(writeOffset, writeLength, write.length);
-        byte[] writeData = Arrays.copyOfRange(write, writeOffset, writeLength+writeOffset);
+        byte[] writeData = Arrays.copyOfRange(write, writeOffset, writeLength + writeOffset);
         var inputBuffer = new SpiTransferBuffer(writeData, new byte[0], writeLength, readDelayNanos / 1000);
         var outputBuffer = new SpiTransferBuffer(new byte[0], read, readLength, readDelayNanos / 1000);
 
@@ -131,22 +156,30 @@ public class FFMSpi extends SpiBase implements Spi {
 
         transferBuffer = IOCTL.call(spiFileDescriptor, Command.getSpiIocMessage(2), transferBuffer);
         var readBytes = transferBuffer.transferBuffer()[1].getRxBuffer();
-        System.arraycopy(readBytes, 0, read,  readOffset, readLength);
+        System.arraycopy(readBytes, 0, read, readOffset, readLength);
 
         logger.trace("{} - Read buffer: {}", path, HexFormatter.format(read));
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int read() {
         return readByte();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int read(byte[] buffer, int offset, int length) {
         return transfer(new byte[length], 0, buffer, offset, length);
     }
 
-
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public byte readByte() {
         var buffer = new byte[1];

--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpi.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/spi/FFMSpi.java
@@ -20,6 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Objects;
 
 public class FFMSpi extends SpiBase implements Spi {
     private static final Logger logger = LoggerFactory.getLogger(FFMSpi.class);
@@ -114,7 +116,10 @@ public class FFMSpi extends SpiBase implements Spi {
 
     @Override
     public void writeThenRead(byte[] write, int writeOffset, int writeLength, int readDelayNanos, byte[] read, int readOffset, int readLength) {
-        var inputBuffer = new SpiTransferBuffer(write, new byte[0], writeLength, readDelayNanos / 1000);
+        Objects.checkFromIndexSize(readOffset, readLength, read.length);
+        Objects.checkFromIndexSize(writeOffset, writeLength, write.length);
+        byte[] writeData = Arrays.copyOfRange(write, writeOffset, writeLength+writeOffset);
+        var inputBuffer = new SpiTransferBuffer(writeData, new byte[0], writeLength, readDelayNanos / 1000);
         var outputBuffer = new SpiTransferBuffer(new byte[0], read, readLength, readDelayNanos / 1000);
 
         var transferBuffer = new SpiMultipleTransferBuffer(inputBuffer, outputBuffer);
@@ -124,7 +129,9 @@ public class FFMSpi extends SpiBase implements Spi {
 
         transferBuffer = IOCTL.call(spiFileDescriptor, Command.getSpiIocMessage(2), transferBuffer);
         var readBytes = transferBuffer.transferBuffer()[1].getRxBuffer();
-        ByteBuffer.wrap(read).put(readBytes);
+      //    ByteBuffer.wrap(read).put(readBytes);
+        System.arraycopy(readBytes, 0, read,  readOffset, readLength);
+
         logger.trace("{} - Read buffer: {}", path, HexFormatter.format(read));
     }
 

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/SPITest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/SPITest.java
@@ -133,7 +133,7 @@ public class SPITest {
         var spiTestData = new IoctlNativeMock.IoctlTestData(SpiMultipleTransferBuffer.class, (answer) -> {
             SpiMultipleTransferBuffer buffer = answer.getArgument(2);
             var inputBuffer = buffer.transferBuffer()[0];
-            var outputBuffer =  buffer.transferBuffer()[1];
+            var outputBuffer = buffer.transferBuffer()[1];
             return new SpiMultipleTransferBuffer(inputBuffer, new SpiTransferBuffer(outputBuffer.getTxBuffer(), inputBuffer.getTxBuffer(), outputBuffer.getTxBuffer().length, 1000));
         });
         try (var _ = FileDescriptorNativeMock.echo();
@@ -146,7 +146,7 @@ public class SPITest {
                 .baud(50_000)
                 .build());
             var buffer = new byte[4];
-            spi.writeThenRead("Test".getBytes(), 0, 4, 500, buffer, 4, 0);
+            spi.writeThenRead("Test".getBytes(), 0, 4, 500, buffer, 0, 4);
             assertEquals(4, buffer.length);
             assertArrayEquals("Test".getBytes(), buffer);
         }

--- a/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/SPITest.java
+++ b/plugins/pi4j-plugin-ffm/src/test/java/com/pi4j/plugin/ffm/unit/SPITest.java
@@ -138,7 +138,6 @@ public class SPITest {
         });
         try (var _ = FileDescriptorNativeMock.echo();
              var _ = IoctlNativeMock.echo(spiTestData)) {
-
             var spi = pi4j.spi().create(SpiConfigBuilder.newInstance(pi4j)
                 .bus(SpiBus.BUS_0)
                 .channel(4)

--- a/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/spi/LinuxFsSpi.java
+++ b/plugins/pi4j-plugin-linuxfs/src/main/java/com/pi4j/plugin/linuxfs/provider/spi/LinuxFsSpi.java
@@ -411,7 +411,7 @@ public class LinuxFsSpi extends SpiBase implements Spi {
 
            //    PeerAccessible
       //  Memory writeBuf = peerArray[firstRecord];//new PeerAccessibleMemory(SPI_BUFFSIZ);
-        txBuf.write(0, write, 0, writeLength);
+        txBuf.write(0, write, writeOffset, writeLength);
         spi_ioc_transfer txEntry = transferArray[firstRecord]; //new spi_ioc_transfer();
 
         // set fields in the tx transfer msg


### PR DESCRIPTION
…s.  In ffm, I only added the required buffer size validation so more work needed.  Also added a test spi write and read,  using separate calls.  This fails on both linuxfs and ffm, i need to use the logic analyzer to make certain this is even possible with these BMP chips.  FFM needs review of any interface that include the offset parm