### PR TITLE
debounce fails. Testing with all merged code hit this change was wron…

### DIFF
--- a/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalInput.java
+++ b/plugins/pi4j-plugin-ffm/src/main/java/com/pi4j/plugin/ffm/providers/gpio/FFMDigitalInput.java
@@ -99,7 +99,7 @@ public class FFMDigitalInput extends DigitalInputBase implements DigitalInput {
                     throw new InitializeException("Debounce value of " + debounce + " is too large");
                 }
                 var debounceAttribute = new LineAttribute(LineAttributeId.GPIO_V2_LINE_ATTR_ID_DEBOUNCE.getValue(), 0, 0, (int) debounce * 1000);
-                attributes.add(new LineConfigAttribute(debounceAttribute, 1L));
+                attributes.add(new LineConfigAttribute(debounceAttribute, 1L << bcm ));
             }
             flags |= switch (pull) {
                 case OFF -> 0;


### PR DESCRIPTION
…g.  Bit shift is required : the parm is a bitmap identifying the lines to which the attribute applies, * with each bit number corresponding to the index into &struct gpio_v2_line_request.offsets